### PR TITLE
build(deps): bump surefile and failsafe plugins to latest 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
     <quarkus.platform.version>2.16.5.Final</quarkus.platform.version>
     <skipITs>true</skipITs>
-    <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
+    <surefire-plugin.version>3.0.0</surefire-plugin.version>
     <wiremock.version>2.27.2</wiremock.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

When working with maven 3.9.x we get the following warning for the `surefire` and `failsafe` plugins:

```shell
[WARNING] Parameter 'localRepository' is deprecated core expression; Avoid use of ArtifactRepository type. If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead.
```

This is fixed with the latest version of the [surefire](https://maven.apache.org/surefire/maven-surefire-plugin/jira-report.html) and [failsafe](https://maven.apache.org/surefire/maven-failsafe-plugin/jira-report.html), version 3.0.0, which includes [this fix](https://issues.apache.org/jira/browse/SUREFIRE-2154).

This was tested with both my local 3.9.1 version and the project's wrapper 3.8.4 version.

