### PR TITLE
ci: added workflow triggering the cli repository when openapi spec is modified

### DIFF
--- a/.github/workflows/inform-cli.yml
+++ b/.github/workflows/inform-cli.yml
@@ -1,0 +1,25 @@
+---
+name: Inform CLI of OpenAPI spec change
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/main/resources/META-INF/openapi.yaml"
+
+jobs:
+  inform_cli_spec_change:
+    runs-on: ubuntu-latest
+    name: Dispatch event for CLI
+    steps:
+      - name: Dispatch
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.CRDA_CLI_REPO_PAT }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: "RHEcosystemAppEng",
+              repo: "crda-cli",
+              event_type: "backend-openapi-spec-modified"
+            })


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

This goes in conjunction with https://github.com/RHEcosystemAppEng/crda-cli/pull/21.

We use an *openapi* spec generator detailed [here](https://github.com/RHEcosystemAppEng/crda-cli/blob/main/Makefile#L153), for generating the *backend api types* [here](https://github.com/RHEcosystemAppEng/crda-cli/blob/main/pkg/backend/api/types_generated.go) for usage in the [crda-cli project](https://github.com/RHEcosystemAppEng/crda-cli/).

The concept for this and the corresponding *crda-cli* workflows is. When the target spec file is modified here in the *backend* project, this workflow will trigger the *cli* project workflow, which in turn will generate the types and verified the types (only types) weren't modified.

We need to set a PAT for the [crda-cli project](https://github.com/RHEcosystemAppEng/crda-cli/) in a secret named *CRDA_CLI_REPO_PAT*. The token requires only the *repo* scope of permissions. Unfortunately, I don't have admin permissions in the *backend* project to do set the secret myself. @ruromero, if you can please help with this, I can provide you with my own token privately.

