### PR TITLE
Add verbose and limit data for anonymous requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,53 @@ $ http :8080/api/v3/dependency-analysis/maven Content-Type:"text/vnd.graphviz" @
 ]
 ```
 
+### Verbose Mode
+
+When the Dependency Graph Analysis returns a JSON report it contains all vulnerability data by default. The _Verbose mode_ can be disabled
+in order to retrieve just a Summary. Use the `verbose=false` Query parameter to disable it.
+
+```bash
+$ http :8080/api/v3/dependency-analysis/maven Content-Type:"text/vnd.graphviz" Accept:"application/json" @'target/dependencies.txt' verbose==false
+
+{
+    "dependencies": [],
+    "summary": {
+        "dependencies": {
+            "scanned": 11,
+            "transitive": 217
+        },
+        "vulnerabilities": {
+            "critical": 1,
+            "direct": 6,
+            "high": 4,
+            "low": 5,
+            "medium": 10,
+            "total": 20
+        }
+    }
+}
+```
+
+### Client Token Authentication
+
+If clients don't provide the token to authenticate against the Vulnerability Provider the default one will be used instead but only the summary
+will be returned in the JSON response.
+
+To provide the client authentication tokens use HTTP Headers in the request. The format for the tokens Headers is `crda-provider-token`. e.g. `crda-snyk-token`:
+
+```bash
+http :8080/api/v3/dependency-analysis/maven Content-Type:"text/vnd.graphviz" Accept:"text/html" @'target/dependencies.txt' crda-snyk-token:the-client-token
+```
+
 ### HTML Report
 
 By default the response Content-Type will be `application/json` but if the `text/html` media type is requested instead, the response
 will be processed and converted into HTML.
+
+The HTML report will show limited information:
+
+- Public vulnerabilities retrieved with the default token will not show the _Exploit Maturity_
+- Private vulnerabilities (i.e. vulnerabilities reported by the provider) will not be displayed.
 
 ```bash
 $ http :8080/api/v3/dependency-analysis/maven Content-Type:"text/vnd.graphviz" Accept:"text/html" @'./src/test/resources/dependencies.txt'

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/Constants.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/Constants.java
@@ -38,6 +38,7 @@ public final class Constants {
     public static final String PKG_MANAGER_HEADER = "pkgManager";
     public static final String SNYK_TOKEN_HEADER = "crda-snyk-token";
     public static final String TIDELIFT_TOKEN_HEADER = "crda-tidelift-token";
+    public static final String VERBOSE_MODE_HEADER = "verbose";
 
     public static final String TEXT_VND_GRAPHVIZ = "text/vnd.graphviz";
     public static final MediaType MULTIPART_MIXED_TYPE = new MediaType("multipart", "mixed");
@@ -49,6 +50,7 @@ public final class Constants {
     public static final String MAVEN_PKG_MANAGER = "maven";
     public static final String REQUEST_CONTENT_PROPERTY = "requestContent";
     public static final String REPORT_PROPERTY = "report";
+    public static final String PROVIDER_PRIVATE_DATA_PROPERTY = "providerPrivateData";
 
     public static final String SNYK_DEP_GRAPH_API_PATH = "/test/dep-graph";
     public static final String TIDELIFT_API_BASE_PATH = "/packages";
@@ -57,6 +59,7 @@ public final class Constants {
     public static final String TRUSTED_CONTENT_VEX_PATH = "/tc";
 
     public static final String DEFAULT_ACCEPT_MEDIA_TYPE = MediaType.APPLICATION_JSON;
+    public static final boolean DEFAULT_VERBOSE_MODE = false;
 
     public static final List<String> PKG_MANAGERS =
             Collections.unmodifiableList(

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/VulnerabilityProvider.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/VulnerabilityProvider.java
@@ -19,6 +19,7 @@
 package com.redhat.ecosystemappeng.crda.integration;
 
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -118,5 +119,14 @@ public class VulnerabilityProvider {
             return (List<String>) o;
         }
         throw new ClientErrorException("Unsupported providers: " + o, 422);
+    }
+
+    public List<String> providersPrivateData(List<String> current, String provider) {
+        if (current == null) {
+            return List.of(provider);
+        }
+        List<String> updated = new ArrayList<>(current);
+        updated.add(provider);
+        return Collections.unmodifiableList(updated);
     }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/backend/CrdaBackendIntegration.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/backend/CrdaBackendIntegration.java
@@ -73,7 +73,8 @@ public class CrdaBackendIntegration extends EndpointRouteBuilder {
                 .setBody().method(GraphUtils.class, "fromPackages")
                 .to(direct("findVulnerabilities"))
                 .to(direct("recommendAllTrustedContent"))
-                .to(direct("report"));
+                .to(direct("jsonReport"))
+                .to(direct("cleanUpResponse"));
 
 
         from(direct("fullDepAnalysis"))
@@ -84,7 +85,8 @@ public class CrdaBackendIntegration extends EndpointRouteBuilder {
             .bean(GraphUtils.class, "fromDotFile")
             .to(direct("findVulnerabilities"))
             .to(direct("recommendVexContent"))
-            .to(direct("report"));
+            .to(direct("report"))
+            .to(direct("cleanUpResponse"));
 
         from(direct("findVulnerabilities"))
             .multicast(AggregationStrategies.bean(ProviderAggregationStrategy.class, "aggregate"))
@@ -92,6 +94,10 @@ public class CrdaBackendIntegration extends EndpointRouteBuilder {
                     .recipientList(method(vulnerabilityProvider, "getProviderEndpoints"))
                 .end()
             .end();
+
+        from(direct("cleanUpResponse"))
+            .removeHeader(Constants.PKG_MANAGER_HEADER)
+            .removeHeader(Constants.VERBOSE_MODE_HEADER);
         //fmt:on
     }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportIntegration.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportIntegration.java
@@ -44,7 +44,8 @@ public class ReportIntegration extends EndpointRouteBuilder {
                 .otherwise()
                     .to(direct("jsonReport"))
             .end()
-            .removeHeader(Constants.PKG_MANAGER_HEADER);
+            .removeHeader(Constants.PKG_MANAGER_HEADER)
+            .removeHeader(Constants.VERBOSE_MODE_HEADER);
 
         from(direct("htmlReport"))
             .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_HTML))
@@ -57,11 +58,13 @@ public class ReportIntegration extends EndpointRouteBuilder {
             .to(direct("htmlReport"))
             .bean(ReportTransformer.class, "attachHtmlReport")
             .setBody(exchangeProperty(Constants.REPORT_PROPERTY))
+            .bean(ReportTransformer.class, "hideJsonPrivateData")
             .marshal().json()
             .marshal().mimeMultipart(Constants.MULTIPART_MIXED_TYPE.getSubtype(), false, false, true);
         
         from(direct("jsonReport"))
             .bean(ReportTransformer.class, "transform")
+            .bean(ReportTransformer.class, "hideJsonPrivateData")
             .marshal().json();
         //fmt:on
     }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportIntegration.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportIntegration.java
@@ -42,10 +42,10 @@ public class ReportIntegration extends EndpointRouteBuilder {
                 .when(exchangeProperty(Constants.REQUEST_CONTENT_PROPERTY).isEqualTo(Constants.MULTIPART_MIXED))
                     .to(direct("multipartReport"))
                 .otherwise()
-                    .to(direct("jsonReport"))
-            .end()
-            .removeHeader(Constants.PKG_MANAGER_HEADER)
-            .removeHeader(Constants.VERBOSE_MODE_HEADER);
+                    .bean(ReportTransformer.class, "transform")
+                    .bean(ReportTransformer.class, "hideJsonPrivateData")
+                    .marshal().json()
+            .end();
 
         from(direct("htmlReport"))
             .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_HTML))
@@ -61,10 +61,9 @@ public class ReportIntegration extends EndpointRouteBuilder {
             .bean(ReportTransformer.class, "hideJsonPrivateData")
             .marshal().json()
             .marshal().mimeMultipart(Constants.MULTIPART_MIXED_TYPE.getSubtype(), false, false, true);
-        
+
         from(direct("jsonReport"))
             .bean(ReportTransformer.class, "transform")
-            .bean(ReportTransformer.class, "hideJsonPrivateData")
             .marshal().json();
         //fmt:on
     }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTemplate.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTemplate.java
@@ -47,7 +47,7 @@ public class ReportTemplate {
     @ConfigProperty(name = "report.snyk.link")
     String packagePath;
 
-    @ConfigProperty(name = "api.snyk.issue.regex")
+    @ConfigProperty(name = "report.snyk.issue.regex")
     String issuePathRegex;
 
     @ConfigProperty(name = "report.vex.link")
@@ -56,9 +56,8 @@ public class ReportTemplate {
     @ConfigProperty(name = "report.sbom.link")
     String sbomPath;
 
-    @ConfigProperty(name = "snyk.signup.link")
+    @ConfigProperty(name = "report.snyk.signup.link")
     String snykSignup;
-
 
     public Map<String, Object> setVariables(
             @Body AnalysisReport report,
@@ -76,7 +75,6 @@ public class ReportTemplate {
         params.put("sbomPath", sbomPath);
         params.put("snykSignup", snykSignup);
 
-
         return params;
     }
 
@@ -91,10 +89,10 @@ public class ReportTemplate {
     @RegisterForReflection
     public static record IssueVisibilityHelper(List<String> providerData) {
         public boolean showIssue(Issue issue) {
-            if (!issue.unique()) {
+            if (!issue.unique() || providerData == null) {
                 return true;
             }
-            return providerData.contains(issue.source());
+            return !providerData.contains(issue.source());
         }
     }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTemplate.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTemplate.java
@@ -56,6 +56,10 @@ public class ReportTemplate {
     @ConfigProperty(name = "report.sbom.link")
     String sbomPath;
 
+    @ConfigProperty(name = "snyk.signup.link")
+    String snykSignup;
+
+
     public Map<String, Object> setVariables(
             @Body AnalysisReport report,
             @ExchangeProperty(Constants.PROVIDER_PRIVATE_DATA_PROPERTY)
@@ -70,6 +74,8 @@ public class ReportTemplate {
         params.put("issueVisibilityHelper", new IssueVisibilityHelper(providerPrivateData));
         params.put("vexPath", vexPath);
         params.put("sbomPath", sbomPath);
+        params.put("snykSignup", snykSignup);
+
 
         return params;
     }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTransformer.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTransformer.java
@@ -30,11 +30,15 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.apache.camel.Body;
 import org.apache.camel.Exchange;
+import org.apache.camel.ExchangeProperty;
+import org.apache.camel.Header;
 import org.apache.camel.attachment.AttachmentMessage;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.traverse.BreadthFirstIterator;
 
+import com.redhat.ecosystemappeng.crda.integration.Constants;
 import com.redhat.ecosystemappeng.crda.integration.GraphUtils;
 import com.redhat.ecosystemappeng.crda.model.AnalysisReport;
 import com.redhat.ecosystemappeng.crda.model.DependenciesSummary;
@@ -55,7 +59,7 @@ import jakarta.ws.rs.core.MediaType;
 @RegisterForReflection
 public class ReportTransformer {
 
-    public AnalysisReport transform(GraphRequest request) {
+    public AnalysisReport transform(@Body GraphRequest request) {
         List<DependencyReport> depsReport = new ArrayList<>();
         List<PackageRef> direct = GraphUtils.getFirstLevel(request.graph());
         VulnerabilityCounter counter = new VulnerabilityCounter();
@@ -131,6 +135,18 @@ public class ReportTransformer {
                 break;
         }
         counter.total.incrementAndGet();
+    }
+
+    public AnalysisReport hideJsonPrivateData(
+            @Body AnalysisReport report,
+            @Header(Constants.VERBOSE_MODE_HEADER) Boolean verbose,
+            @ExchangeProperty(Constants.PROVIDER_PRIVATE_DATA_PROPERTY)
+                    List<String> providerPrivateData) {
+        if (Boolean.FALSE.equals(verbose)
+                || (providerPrivateData != null && !providerPrivateData.isEmpty())) {
+            return new AnalysisReport(report.summary(), null);
+        }
+        return report;
     }
 
     public void attachHtmlReport(Exchange exchange) {

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTransformer.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/report/ReportTransformer.java
@@ -144,7 +144,7 @@ public class ReportTransformer {
                     List<String> providerPrivateData) {
         if (Boolean.FALSE.equals(verbose)
                 || (providerPrivateData != null && !providerPrivateData.isEmpty())) {
-            return new AnalysisReport(report.summary(), null);
+            return new AnalysisReport(report.summary(), Collections.emptyList());
         }
         return report;
     }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/snyk/SnykAggregationStrategy.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/snyk/SnykAggregationStrategy.java
@@ -81,7 +81,8 @@ public class SnykAggregationStrategy {
                 .severity(Severity.fromValue(data.get("severity").asText()))
                 .cvss(CvssParser.fromVectorString(cvssV3))
                 .cvssScore(data.get("cvssScore").floatValue())
-                .cves(cves);
+                .cves(cves)
+                .unique(cves.isEmpty());
         return builder.build();
     }
 }

--- a/src/main/java/com/redhat/ecosystemappeng/crda/model/Issue.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/model/Issue.java
@@ -32,7 +32,8 @@ public record Issue(
         CvssVector cvss,
         Float cvssScore,
         Severity severity,
-        Set<String> cves) {
+        Set<String> cves,
+        boolean unique) {
 
     public Issue {
         Objects.requireNonNull(id);
@@ -54,6 +55,7 @@ public record Issue(
         Float cvssScore;
         Severity severity;
         Set<String> cves;
+        boolean unique;
 
         public Builder(String id) {
             this.id = id;
@@ -89,8 +91,13 @@ public record Issue(
             return this;
         }
 
+        public Builder unique(boolean unique) {
+            this.unique = unique;
+            return this;
+        }
+
         public Issue build() {
-            return new Issue(id, title, source, cvss, cvssScore, severity, cves);
+            return new Issue(id, title, source, cvss, cvssScore, severity, cves, unique);
         }
     }
 }

--- a/src/main/resources/META-INF/openapi.yaml
+++ b/src/main/resources/META-INF/openapi.yaml
@@ -250,6 +250,8 @@ components:
           type: array
           items:
             type: string
+        unique:
+          type: boolean
       example:
         id: SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426
         title: Denial of Service (DoS)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,7 @@ report.trustedContent.link=https://maven.repository.redhat.com/ga/
 report.snyk.link=https://security.snyk.io/package/maven/
 report.vex.link=https://tc-storage-mvp.s3.amazonaws.com/vexes/
 report.sbom.link=https://tc-storage-mvp.s3.amazonaws.com/sboms/sbom.json
+snyk.signup.link=https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9
 
 ## See https://quarkus.io/guides/native-and-ssl
 quarkus.ssl.native=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,12 +9,12 @@ api.tidelift.token=placeholder
 api.tidelift.host=https://api.tidelift.com/external-api/v1
 api.tidelift.disabled=true
 
-api.snyk.issue.regex=https://security.snyk.io/vuln/%s?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/%s
+report.snyk.issue.regex=https://security.snyk.io/vuln/%s?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/%s
 report.trustedContent.link=https://maven.repository.redhat.com/ga/
 report.snyk.link=https://security.snyk.io/package/maven/
 report.vex.link=https://tc-storage-mvp.s3.amazonaws.com/vexes/
 report.sbom.link=https://tc-storage-mvp.s3.amazonaws.com/sboms/sbom.json
-snyk.signup.link=https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9
+report.snyk.signup.link=https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9
 
 ## See https://quarkus.io/guides/native-and-ssl
 quarkus.ssl.native=true

--- a/src/main/resources/freemarker/templates/report.ftl
+++ b/src/main/resources/freemarker/templates/report.ftl
@@ -206,9 +206,9 @@
                                         <thead>
                                         <tr>
                                             <th scope="col">Severity</th>
-                                            <th scope="col">Exploit Maturity</th>
+                                            <th scope="col" style="width: 18%">Exploit Maturity</th>
                                             <th scope="col">Description</th>
-                                            <th scope="col" style="width: 15%">CVSS</th>
+                                            <th scope="col" style="width: 13%">CVSS</th>
                                             <th scope="col">CVE</th>
                                             <th scope="col">Remediation</th>
                                         </tr>
@@ -230,7 +230,15 @@
                                                     </span>
                                                 </span>
                                                 </td>
-                                                <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
+                                                <#if body.issueVisibilityHelper.showIssue(vulnerability)>
+                                                    <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
+                                                <#else>
+                                                    <td><a href="${body.snykSignup}"
+                                                           target="_blank">
+                                                            Sign up for a free Snyk account
+                                                        </a>to find out which vulnerabilities have a publicly known exploits
+                                                    </td>
+                                                </#if>
                                                 <td>${vulnerability.title()}</td>
                                                 <td>
                                                     <#assign barNum = vulnerability.cvssScore() *10>
@@ -296,9 +304,9 @@
                                 <tr>
                                     <th scope="col" style="width: 21%">Dependencies</th>
                                     <th scope="col">Severity</th>
-                                    <th scope="col">Exploit Maturity</th>
+                                    <th scope="col" style="width: 18%">Exploit Maturity</th>
                                     <th scope="col">Description</th>
-                                    <th scope="col" style="width: 15%">CVSS</th>
+                                    <th scope="col" style="width: 13%">CVSS</th>
                                     <th scope="col">CVE</th>
                                     <th scope="col">Remediation</th>
                                 </tr>
@@ -331,7 +339,15 @@
                                                             </span>
                                                         </span>
                                                 </td>
-                                                <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
+                                                <#if body.issueVisibilityHelper.showIssue(vulnerability)>
+                                                    <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
+                                                <#else>
+                                                    <td><a href="${body.snykSignup}"
+                                                           target="_blank">
+                                                            Sign up for a free Snyk account
+                                                        </a>to find out which vulnerabilities have a publicly known exploits
+                                                    </td>
+                                                </#if>
                                                 <td>${vulnerability.title()}</td>
                                                 <td>
                                                     <#assign barNum = vulnerability.cvssScore() *10>

--- a/src/main/resources/freemarker/templates/report.ftl
+++ b/src/main/resources/freemarker/templates/report.ftl
@@ -206,6 +206,7 @@
                                         <thead>
                                         <tr>
                                             <th scope="col">Severity</th>
+                                            <th scope="col">Exploit Maturity</th>
                                             <th scope="col">Description</th>
                                             <th scope="col" style="width: 15%">CVSS</th>
                                             <th scope="col">CVE</th>
@@ -229,6 +230,7 @@
                                                     </span>
                                                 </span>
                                                 </td>
+                                                <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
                                                 <td>${vulnerability.title()}</td>
                                                 <td>
                                                     <#assign barNum = vulnerability.cvssScore() *10>
@@ -294,6 +296,7 @@
                                 <tr>
                                     <th scope="col" style="width: 21%">Dependencies</th>
                                     <th scope="col">Severity</th>
+                                    <th scope="col">Exploit Maturity</th>
                                     <th scope="col">Description</th>
                                     <th scope="col" style="width: 15%">CVSS</th>
                                     <th scope="col">CVE</th>
@@ -328,6 +331,7 @@
                                                             </span>
                                                         </span>
                                                 </td>
+                                                <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
                                                 <td>${vulnerability.title()}</td>
                                                 <td>
                                                     <#assign barNum = vulnerability.cvssScore() *10>

--- a/src/main/resources/freemarker/templates/report.ftl
+++ b/src/main/resources/freemarker/templates/report.ftl
@@ -165,10 +165,18 @@
                         </div>
                     </td>
                     <td>
-                        <a href="${issueLink(dependency.highestVulnerability().id())}"
-                           target="_blank">
-                            ${dependency.highestVulnerability().id()}
-                        </a>
+                        <#if body.issueVisibilityHelper.showIssue(dependency.highestVulnerability())>
+                            <a href="${issueLink(dependency.highestVulnerability().id())}"
+                            target="_blank">
+                                ${dependency.highestVulnerability().id()}
+                            </a>
+                        <#else>
+                            <a href="${body.snykSignup}"
+                                target="_blank">
+                                Sign up for a free Snyk account
+                            </a>to learn about the vulnerabilities found
+                        </#if>
+                        
                     </td>
                 <#else>
                     <td>--</td>
@@ -217,29 +225,37 @@
                                         <#list dependency.issues() as vulnerability>
                                             <tr>
                                                 <#assign severity = vulnerability.severity()>
-                                                <td>
-                                                    <#if severity == "critical" || severity == "high">
-                                                    <span class="pf-c-label pf-m-red">
-                                                <#elseif (severity == "medium") >
-                                                    <span class="pf-c-label pf-m-orange">
-                                                <#elseif (severity == "low") >
-                                                    <span class="pf-c-label pf-m-gold">
-                                                </#if>
-                                                    <span class="pf-c-label__content">
-                                                        ${vulnerability.severity()}
-                                                    </span>
-                                                </span>
-                                                </td>
                                                 <#if body.issueVisibilityHelper.showIssue(vulnerability)>
-                                                    <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
+                                                    <td>
+                                                        <#if severity == "critical" || severity == "high">
+                                                        <span class="pf-c-label pf-m-red">
+                                                    <#elseif (severity == "medium") >
+                                                        <span class="pf-c-label pf-m-orange">
+                                                    <#elseif (severity == "low") >
+                                                        <span class="pf-c-label pf-m-gold">
+                                                    </#if>
+                                                        <span class="pf-c-label__content">
+                                                            ${vulnerability.severity()}
+                                                        </span>
+                                                    </span>
+                                                    </td>
+                                                    <#if body.issueVisibilityHelper.showIssue(vulnerability)>
+                                                        <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
+                                                    <#else>
+                                                        <td><a href="${body.snykSignup}"
+                                                            target="_blank">
+                                                                Sign up for a free Snyk account
+                                                            </a>to find out which vulnerabilities have a publicly known exploits
+                                                        </td>
+                                                    </#if>
+                                                    <td>${vulnerability.title()}</td>
                                                 <#else>
-                                                    <td><a href="${body.snykSignup}"
-                                                           target="_blank">
+                                                    <td colspan="3"><a href="${body.snykSignup}"
+                                                            target="_blank">
                                                             Sign up for a free Snyk account
                                                         </a>to find out which vulnerabilities have a publicly known exploits
                                                     </td>
                                                 </#if>
-                                                <td>${vulnerability.title()}</td>
                                                 <td>
                                                     <#assign barNum = vulnerability.cvssScore() *10>
                                                     <#if severity == "critical" || severity == "high">
@@ -280,10 +296,17 @@
                                                         </button>
                                                         <#assign remediation = dependency.findRemediationByIssue(vulnerability)!>
                                                     <#else>
-                                                        <a href="${issueLink(vulnerability.id())}"
-                                                           target="_blank">
-                                                            ${vulnerability.id()}
-                                                        </a>
+                                                        <#if body.issueVisibilityHelper.showIssue(vulnerability)>
+                                                            <a href="${issueLink(vulnerability.id())}"
+                                                            target="_blank">
+                                                                ${vulnerability.id()}
+                                                            </a>
+                                                        <#else>
+                                                            <a href="${body.snykSignup}"
+                                                                target="_blank">
+                                                                Sign up for a free Snyk account
+                                                            </a>to learn about the vulnerabilities found
+                                                        </#if>
                                                     </#if>
                                                 </td>
                                             </tr>
@@ -318,14 +341,15 @@
                                         <#list transDependency.issues() as vulnerability>
                                             <#assign severity = vulnerability.severity()>
                                             <tr>
-                                                <#if vulnerability?index == 0>
-                                                    <td rowspan="${numOfVul}">
-                                                        <a href="${packageLink(transDependency.ref())}"
-                                                           target="_blank">
-                                                            ${transDependency.ref().name()}
-                                                        </a>
-                                                    </td>
-                                                </#if>
+                                            <#if vulnerability?index == 0>
+                                                <td rowspan="${numOfVul}">
+                                                    <a href="${packageLink(transDependency.ref())}"
+                                                        target="_blank">
+                                                        ${transDependency.ref().name()}
+                                                    </a>
+                                                </td>
+                                            </#if>
+                                            <#if body.issueVisibilityHelper.showIssue(vulnerability)>
                                                 <td style="padding-left: 0.5rem">
                                                     <#if severity == "critical" || severity == "high">
                                                     <span class="pf-c-label pf-m-red">
@@ -339,16 +363,15 @@
                                                             </span>
                                                         </span>
                                                 </td>
-                                                <#if body.issueVisibilityHelper.showIssue(vulnerability)>
-                                                    <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
-                                                <#else>
-                                                    <td><a href="${body.snykSignup}"
-                                                           target="_blank">
-                                                            Sign up for a free Snyk account
-                                                        </a>to find out which vulnerabilities have a publicly known exploits
-                                                    </td>
-                                                </#if>
+                                                <td>${vulnerability.cvss().exploitCodeMaturity()!"No known exploit"}</td>
                                                 <td>${vulnerability.title()}</td>
+                                            <#else>
+                                                <td colspan="3"><a href="${body.snykSignup}"
+                                                        target="_blank">
+                                                        Sign up for a free Snyk account
+                                                    </a>to find out which vulnerabilities have a publicly known exploits
+                                                </td>
+                                            </#if>
                                                 <td>
                                                     <#assign barNum = vulnerability.cvssScore() *10>
                                                     <#if severity == "critical" || severity == "high">
@@ -388,10 +411,17 @@
                                                             ${remediation.version()}
                                                         </button>
                                                     <#else>
-                                                        <a href="${issueLink(vulnerability.id())}"
-                                                           target="_blank">
-                                                            ${vulnerability.id()}
-                                                        </a>
+                                                        <#if body.issueVisibilityHelper.showIssue(vulnerability)>
+                                                            <a href="${issueLink(vulnerability.id())}"
+                                                            target="_blank">
+                                                                ${vulnerability.id()}
+                                                            </a>
+                                                        <#else>
+                                                            <a href="${body.snykSignup}"
+                                                                target="_blank">
+                                                                Sign up for a free Snyk account
+                                                            </a>to learn about the vulnerabilities found
+                                                        </#if>
                                                     </#if>
                                                 </td>
                                             </tr>

--- a/src/test/resources/__files/component_snyk.json
+++ b/src/test/resources/__files/component_snyk.json
@@ -1,236 +1,203 @@
 {
-    "summary": {
-        "dependencies": {
-            "scanned": 2,
-            "transitive": 0
-        },
-        "vulnerabilities": {
-            "total": 6,
-            "direct": 2,
-            "critical": 0,
-            "high": 2,
-            "medium": 4,
-            "low": 0
-        }
-    },
-    "dependencies": [
-        {
-            "ref": {
-                "name": "com.fasterxml.jackson.core:jackson-databind",
-                "version": "2.13.1"
-            },
-            "highestVulnerability": {
-                "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
-                "title": "Denial of Service (DoS)",
-                "source": "snyk",
-                "cvss": {
-                    "attackVector": "Network",
-                    "attackComplexity": "Low",
-                    "privilegesRequired": "None",
-                    "userInteraction": "None",
-                    "scope": "Unchanged",
-                    "confidentialityImpact": "None",
-                    "integrityImpact": "None",
-                    "availabilityImpact": "High",
-                    "exploitCodeMaturity": null,
-                    "remediationLevel": null,
-                    "reportConfidence": null,
-                    "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                },
-                "cvssScore": 7.5,
-                "severity": "HIGH",
-                "cves": [
-                    "CVE-2020-36518"
-                ]
-            },
-            "issues": [
-                {
-                    "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
-                    "title": "Denial of Service (DoS)",
-                    "source": "snyk",
-                    "cvss": {
-                        "attackVector": "Network",
-                        "attackComplexity": "Low",
-                        "privilegesRequired": "None",
-                        "userInteraction": "None",
-                        "scope": "Unchanged",
-                        "confidentialityImpact": "None",
-                        "integrityImpact": "None",
-                        "availabilityImpact": "High",
-                        "exploitCodeMaturity": null,
-                        "remediationLevel": null,
-                        "reportConfidence": null,
-                        "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                    },
-                    "cvssScore": 7.5,
-                    "severity": "HIGH",
-                    "cves": [
-                        "CVE-2020-36518"
-                    ]
-                },
-                {
-                    "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
-                    "title": "Denial of Service (DoS)",
-                    "source": "snyk",
-                    "cvss": {
-                        "attackVector": "Network",
-                        "attackComplexity": "Low",
-                        "privilegesRequired": "None",
-                        "userInteraction": "None",
-                        "scope": "Unchanged",
-                        "confidentialityImpact": "None",
-                        "integrityImpact": "None",
-                        "availabilityImpact": "High",
-                        "exploitCodeMaturity": null,
-                        "remediationLevel": null,
-                        "reportConfidence": null,
-                        "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                    },
-                    "cvssScore": 7.5,
-                    "severity": "HIGH",
-                    "cves": [
-                        "CVE-2020-36518"
-                    ]
-                },
-                {
-                    "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424",
-                    "title": "Denial of Service (DoS)",
-                    "source": "snyk",
-                    "cvss": {
-                        "attackVector": "Network",
-                        "attackComplexity": "High",
-                        "privilegesRequired": "None",
-                        "userInteraction": "None",
-                        "scope": "Unchanged",
-                        "confidentialityImpact": "None",
-                        "integrityImpact": "None",
-                        "availabilityImpact": "High",
-                        "exploitCodeMaturity": "Proof of concept code",
-                        "remediationLevel": null,
-                        "reportConfidence": null,
-                        "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
-                    },
-                    "cvssScore": 5.9,
-                    "severity": "MEDIUM",
-                    "cves": [
-                        "CVE-2022-42004"
-                    ]
-                },
-                {
-                    "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
-                    "title": "Denial of Service (DoS)",
-                    "source": "snyk",
-                    "cvss": {
-                        "attackVector": "Network",
-                        "attackComplexity": "High",
-                        "privilegesRequired": "None",
-                        "userInteraction": "None",
-                        "scope": "Unchanged",
-                        "confidentialityImpact": "None",
-                        "integrityImpact": "None",
-                        "availabilityImpact": "High",
-                        "exploitCodeMaturity": "Proof of concept code",
-                        "remediationLevel": null,
-                        "reportConfidence": null,
-                        "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
-                    },
-                    "cvssScore": 5.9,
-                    "severity": "MEDIUM",
-                    "cves": [
-                        "CVE-2022-42003"
-                    ]
-                },
-                {
-                    "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424",
-                    "title": "Denial of Service (DoS)",
-                    "source": "snyk",
-                    "cvss": {
-                        "attackVector": "Network",
-                        "attackComplexity": "High",
-                        "privilegesRequired": "None",
-                        "userInteraction": "None",
-                        "scope": "Unchanged",
-                        "confidentialityImpact": "None",
-                        "integrityImpact": "None",
-                        "availabilityImpact": "High",
-                        "exploitCodeMaturity": "Proof of concept code",
-                        "remediationLevel": null,
-                        "reportConfidence": null,
-                        "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
-                    },
-                    "cvssScore": 5.9,
-                    "severity": "MEDIUM",
-                    "cves": [
-                        "CVE-2022-42004"
-                    ]
-                },
-                {
-                    "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
-                    "title": "Denial of Service (DoS)",
-                    "source": "snyk",
-                    "cvss": {
-                        "attackVector": "Network",
-                        "attackComplexity": "High",
-                        "privilegesRequired": "None",
-                        "userInteraction": "None",
-                        "scope": "Unchanged",
-                        "confidentialityImpact": "None",
-                        "integrityImpact": "None",
-                        "availabilityImpact": "High",
-                        "exploitCodeMaturity": "Proof of concept code",
-                        "remediationLevel": null,
-                        "reportConfidence": null,
-                        "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
-                    },
-                    "cvssScore": 5.9,
-                    "severity": "MEDIUM",
-                    "cves": [
-                        "CVE-2022-42003"
-                    ]
-                }
-            ],
-            "transitive": [
-                
-            ],
-            "remediations": {
-                "CVE-2022-42004": {
-                    "issueRef": "CVE-2022-42004",
-                    "mavenPackage": {
-                        "name": "com.fasterxml.jackson.core:jackson-databind",
-                        "version": "2.13.1.Final-redhat-00002"
-                    },
-                    "productStatus": "known_not_affected"
-                },
-                "CVE-2020-36518": {
-                    "issueRef": "CVE-2020-36518",
-                    "mavenPackage": {
-                        "name": "com.fasterxml.jackson.core:jackson-databind",
-                        "version": "2.13.1.Final-redhat-00002"
-                    },
-                    "productStatus": "known_affected"
-                }
-            },
-            "recommendation": null
-        },
-        {
-            "ref": {
-                "name": "io.quarkus:quarkus-jdbc-postgresql",
-                "version": "2.13.5"
-            },
-            "highestVulnerability": null,
-            "issues": [
-                
-            ],
-            "transitive": [
-                
-            ],
-            "remediations": {
-                
-            },
-            "recommendation": {
-                "name": "io.quarkus:quarkus-jdbc-postgresql",
-                "version": "2.13.5.redhat-00001"
-            }
-        }
-    ]
+	"summary": {
+		"dependencies": {
+			"scanned": 2,
+			"transitive": 0
+		},
+		"vulnerabilities": {
+			"total": 6,
+			"direct": 2,
+			"critical": 0,
+			"high": 2,
+			"medium": 4,
+			"low": 0
+		}
+	},
+	"dependencies": [{
+		"ref": {
+			"name": "com.fasterxml.jackson.core:jackson-databind",
+			"version": "2.13.1"
+		},
+		"highestVulnerability": {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "Low",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": null,
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+			},
+			"cvssScore": 7.5,
+			"severity": "HIGH",
+			"cves": ["CVE-2020-36518"],
+			"unique": false
+		},
+		"issues": [{
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "Low",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": null,
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+			},
+			"cvssScore": 7.5,
+			"severity": "HIGH",
+			"cves": ["CVE-2020-36518"],
+			"unique": false
+		}, {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "Low",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": null,
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+			},
+			"cvssScore": 7.5,
+			"severity": "HIGH",
+			"cves": ["CVE-2020-36518"],
+			"unique": false
+		}, {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "High",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": "Proof of concept code",
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+			},
+			"cvssScore": 5.9,
+			"severity": "MEDIUM",
+			"cves": [],
+			"unique": true
+		}, {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "High",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": "Proof of concept code",
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+			},
+			"cvssScore": 5.9,
+			"severity": "MEDIUM",
+			"cves": ["CVE-2022-42003"],
+			"unique": false
+		}, {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "High",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": "Proof of concept code",
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+			},
+			"cvssScore": 5.9,
+			"severity": "MEDIUM",
+			"cves": [],
+			"unique": true
+		}, {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "High",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": "Proof of concept code",
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+			},
+			"cvssScore": 5.9,
+			"severity": "MEDIUM",
+			"cves": ["CVE-2022-42003"],
+			"unique": false
+		}],
+		"transitive": [],
+		"remediations": {
+			"CVE-2020-36518": {
+				"issueRef": "CVE-2020-36518",
+				"mavenPackage": {
+					"name": "com.fasterxml.jackson.core:jackson-databind",
+					"version": "2.13.1.Final-redhat-00002"
+				},
+				"productStatus": "known_affected"
+			}
+		},
+		"recommendation": null
+	}, {
+		"ref": {
+			"name": "io.quarkus:quarkus-jdbc-postgresql",
+			"version": "2.13.5"
+		},
+		"highestVulnerability": null,
+		"issues": [],
+		"transitive": [],
+		"remediations": {},
+		"recommendation": {
+			"name": "io.quarkus:quarkus-jdbc-postgresql",
+			"version": "2.13.5.redhat-00001"
+		}
+	}]
 }

--- a/src/test/resources/__files/expected_dep_snyk.json
+++ b/src/test/resources/__files/expected_dep_snyk.json
@@ -1,284 +1,247 @@
 {
-    "summary": {
-        "dependencies": {
-            "scanned": 2,
-            "transitive": 7
-        },
-        "vulnerabilities": {
-            "total": 4,
-            "direct": 2,
-            "critical": 0,
-            "high": 1,
-            "medium": 3,
-            "low": 0
-        }
-    },
-    "dependencies": [
-        {
-            "ref": {
-                "name": "io.quarkus:quarkus-hibernate-orm",
-                "version": "2.13.5.Final"
-            },
-            "highestVulnerability": {
-                "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
-                "title": "Denial of Service (DoS)",
-                "source": "snyk",
-                "cvss": {
-                    "attackVector": "Network",
-                    "attackComplexity": "Low",
-                    "privilegesRequired": "None",
-                    "userInteraction": "None",
-                    "scope": "Unchanged",
-                    "confidentialityImpact": "None",
-                    "integrityImpact": "None",
-                    "availabilityImpact": "High",
-                    "exploitCodeMaturity": null,
-                    "remediationLevel": null,
-                    "reportConfidence": null,
-                    "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                },
-                "cvssScore": 7.5,
-                "severity": "HIGH",
-                "cves": [
-                    "CVE-2020-36518"
-                ]
-            },
-            "issues": [
-                
-            ],
-            "transitive": [
-                {
-                    "ref": {
-                        "name": "com.fasterxml.jackson.core:jackson-databind",
-                        "version": "2.13.1"
-                    },
-                    "highestVulnerability": {
-                        "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
-                        "title": "Denial of Service (DoS)",
-                        "source": "snyk",
-                        "cvss": {
-                            "attackVector": "Network",
-                            "attackComplexity": "Low",
-                            "privilegesRequired": "None",
-                            "userInteraction": "None",
-                            "scope": "Unchanged",
-                            "confidentialityImpact": "None",
-                            "integrityImpact": "None",
-                            "availabilityImpact": "High",
-                            "exploitCodeMaturity": null,
-                            "remediationLevel": null,
-                            "reportConfidence": null,
-                            "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                        },
-                        "cvssScore": 7.5,
-                        "severity": "HIGH",
-                        "cves": [
-                            "CVE-2020-36518"
-                        ]
-                    },
-                    "issues": [
-                        {
-                            "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
-                            "title": "Denial of Service (DoS)",
-                            "source": "snyk",
-                            "cvss": {
-                                "attackVector": "Network",
-                                "attackComplexity": "Low",
-                                "privilegesRequired": "None",
-                                "userInteraction": "None",
-                                "scope": "Unchanged",
-                                "confidentialityImpact": "None",
-                                "integrityImpact": "None",
-                                "availabilityImpact": "High",
-                                "exploitCodeMaturity": null,
-                                "remediationLevel": null,
-                                "reportConfidence": null,
-                                "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                            },
-                            "cvssScore": 7.5,
-                            "severity": "HIGH",
-                            "cves": [
-                                "CVE-2020-36518"
-                            ]
-                        },
-                        {
-                            "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424",
-                            "title": "Denial of Service (DoS)",
-                            "source": "snyk",
-                            "cvss": {
-                                "attackVector": "Network",
-                                "attackComplexity": "High",
-                                "privilegesRequired": "None",
-                                "userInteraction": "None",
-                                "scope": "Unchanged",
-                                "confidentialityImpact": "None",
-                                "integrityImpact": "None",
-                                "availabilityImpact": "High",
-                                "exploitCodeMaturity": "Proof of concept code",
-                                "remediationLevel": null,
-                                "reportConfidence": null,
-                                "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
-                            },
-                            "cvssScore": 5.9,
-                            "severity": "MEDIUM",
-                            "cves": [
-                                "CVE-2022-42004"
-                            ]
-                        },
-                        {
-                            "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
-                            "title": "Denial of Service (DoS)",
-                            "source": "snyk",
-                            "cvss": {
-                                "attackVector": "Network",
-                                "attackComplexity": "High",
-                                "privilegesRequired": "None",
-                                "userInteraction": "None",
-                                "scope": "Unchanged",
-                                "confidentialityImpact": "None",
-                                "integrityImpact": "None",
-                                "availabilityImpact": "High",
-                                "exploitCodeMaturity": "Proof of concept code",
-                                "remediationLevel": null,
-                                "reportConfidence": null,
-                                "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
-                            },
-                            "cvssScore": 5.9,
-                            "severity": "MEDIUM",
-                            "cves": [
-                                "CVE-2022-42003"
-                            ]
-                        }
-                    ],
-                    "remediations": {
-                        "CVE-2022-42004": {
-                            "issueRef": "CVE-2022-42004",
-                            "mavenPackage": {
-                                "name": "com.fasterxml.jackson.core:jackson-databind",
-                                "version": "2.13.1.Final-redhat-00002"
-                            },
-                            "productStatus": "known_not_affected"
-                        },
-                        "CVE-2020-36518": {
-                            "issueRef": "CVE-2020-36518",
-                            "mavenPackage": {
-                                "name": "com.fasterxml.jackson.core:jackson-databind",
-                                "version": "2.13.1.Final-redhat-00002"
-                            },
-                            "productStatus": "known_affected"
-                        }
-                    }
-                }
-            ],
-            "remediations": {
-                
-            },
-            "recommendation": null
-        },
-        {
-            "ref": {
-                "name": "io.quarkus:quarkus-jdbc-postgresql",
-                "version": "2.13.5.Final"
-            },
-            "highestVulnerability": {
-                "id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
-                "title": "Information Exposure",
-                "source": "snyk",
-                "cvss": {
-                    "attackVector": "Local",
-                    "attackComplexity": "High",
-                    "privilegesRequired": "Low",
-                    "userInteraction": "None",
-                    "scope": "Unchanged",
-                    "confidentialityImpact": "High",
-                    "integrityImpact": "None",
-                    "availabilityImpact": "None",
-                    "exploitCodeMaturity": null,
-                    "remediationLevel": null,
-                    "reportConfidence": null,
-                    "cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
-                },
-                "cvssScore": 4.7,
-                "severity": "MEDIUM",
-                "cves": [
-                    "CVE-2022-41946"
-                ]
-            },
-            "issues": [
-                
-            ],
-            "transitive": [
-                {
-                    "ref": {
-                        "name": "org.postgresql:postgresql",
-                        "version": "42.5.0"
-                    },
-                    "highestVulnerability": {
-                        "id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
-                        "title": "Information Exposure",
-                        "source": "snyk",
-                        "cvss": {
-                            "attackVector": "Local",
-                            "attackComplexity": "High",
-                            "privilegesRequired": "Low",
-                            "userInteraction": "None",
-                            "scope": "Unchanged",
-                            "confidentialityImpact": "High",
-                            "integrityImpact": "None",
-                            "availabilityImpact": "None",
-                            "exploitCodeMaturity": null,
-                            "remediationLevel": null,
-                            "reportConfidence": null,
-                            "cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
-                        },
-                        "cvssScore": 4.7,
-                        "severity": "MEDIUM",
-                        "cves": [
-                            "CVE-2022-41946"
-                        ]
-                    },
-                    "issues": [
-                        {
-                            "id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
-                            "title": "Information Exposure",
-                            "source": "snyk",
-                            "cvss": {
-                                "attackVector": "Local",
-                                "attackComplexity": "High",
-                                "privilegesRequired": "Low",
-                                "userInteraction": "None",
-                                "scope": "Unchanged",
-                                "confidentialityImpact": "High",
-                                "integrityImpact": "None",
-                                "availabilityImpact": "None",
-                                "exploitCodeMaturity": null,
-                                "remediationLevel": null,
-                                "reportConfidence": null,
-                                "cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
-                            },
-                            "cvssScore": 4.7,
-                            "severity": "MEDIUM",
-                            "cves": [
-                                "CVE-2022-41946"
-                            ]
-                        }
-                    ],
-                    "remediations": {
-                        "CVE-2022-41946": {
-                            "issueRef": "CVE-2022-41946",
-                            "mavenPackage": {
-                                "name": "io.quarkus:quarkus-jdbc-postgresql",
-                                "version": "2.13.7.Final-redhat-00003"
-                            },
-                            "productStatus": "fixed"
-                        }
-                    }
-                }
-            ],
-            "remediations": {
-                
-            },
-            "recommendation": null
-        }
-    ]
+	"summary": {
+		"dependencies": {
+			"scanned": 2,
+			"transitive": 7
+		},
+		"vulnerabilities": {
+			"total": 4,
+			"direct": 2,
+			"critical": 0,
+			"high": 1,
+			"medium": 3,
+			"low": 0
+		}
+	},
+	"dependencies": [{
+		"ref": {
+			"name": "io.quarkus:quarkus-hibernate-orm",
+			"version": "2.13.5.Final"
+		},
+		"highestVulnerability": {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "Low",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": null,
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+			},
+			"cvssScore": 7.5,
+			"severity": "HIGH",
+			"cves": ["CVE-2020-36518"],
+			"unique": false
+		},
+		"issues": [],
+		"transitive": [{
+			"ref": {
+				"name": "com.fasterxml.jackson.core:jackson-databind",
+				"version": "2.13.1"
+			},
+			"highestVulnerability": {
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "Low",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+				},
+				"cvssScore": 7.5,
+				"severity": "HIGH",
+				"cves": ["CVE-2020-36518"],
+				"unique": false
+			},
+			"issues": [{
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "Low",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+				},
+				"cvssScore": 7.5,
+				"severity": "HIGH",
+				"cves": ["CVE-2020-36518"],
+				"unique": false
+			}, {
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "High",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": "Proof of concept code",
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+				},
+				"cvssScore": 5.9,
+				"severity": "MEDIUM",
+				"cves": [],
+				"unique": true
+			}, {
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "High",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": "Proof of concept code",
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+				},
+				"cvssScore": 5.9,
+				"severity": "MEDIUM",
+				"cves": ["CVE-2022-42003"],
+				"unique": false
+			}],
+			"remediations": {
+				"CVE-2020-36518": {
+					"issueRef": "CVE-2020-36518",
+					"mavenPackage": {
+						"name": "com.fasterxml.jackson.core:jackson-databind",
+						"version": "2.13.1.Final-redhat-00002"
+					},
+					"productStatus": "known_affected"
+				}
+			}
+		}],
+		"remediations": {},
+		"recommendation": null
+	}, {
+		"ref": {
+			"name": "io.quarkus:quarkus-jdbc-postgresql",
+			"version": "2.13.5.Final"
+		},
+		"highestVulnerability": {
+			"id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
+			"title": "Information Exposure",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Local",
+				"attackComplexity": "High",
+				"privilegesRequired": "Low",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "High",
+				"integrityImpact": "None",
+				"availabilityImpact": "None",
+				"exploitCodeMaturity": null,
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+			},
+			"cvssScore": 4.7,
+			"severity": "MEDIUM",
+			"cves": ["CVE-2022-41946"],
+			"unique": false
+		},
+		"issues": [],
+		"transitive": [{
+			"ref": {
+				"name": "org.postgresql:postgresql",
+				"version": "42.5.0"
+			},
+			"highestVulnerability": {
+				"id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
+				"title": "Information Exposure",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Local",
+					"attackComplexity": "High",
+					"privilegesRequired": "Low",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "High",
+					"integrityImpact": "None",
+					"availabilityImpact": "None",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+				},
+				"cvssScore": 4.7,
+				"severity": "MEDIUM",
+				"cves": ["CVE-2022-41946"],
+				"unique": false
+			},
+			"issues": [{
+				"id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
+				"title": "Information Exposure",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Local",
+					"attackComplexity": "High",
+					"privilegesRequired": "Low",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "High",
+					"integrityImpact": "None",
+					"availabilityImpact": "None",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+				},
+				"cvssScore": 4.7,
+				"severity": "MEDIUM",
+				"cves": ["CVE-2022-41946"],
+				"unique": false
+			}],
+			"remediations": {
+				"CVE-2022-41946": {
+					"issueRef": "CVE-2022-41946",
+					"mavenPackage": {
+						"name": "io.quarkus:quarkus-jdbc-postgresql",
+						"version": "2.13.7.Final-redhat-00003"
+					},
+					"productStatus": "fixed"
+				}
+			}
+		}],
+		"remediations": {},
+		"recommendation": null
+	}]
 }

--- a/src/test/resources/__files/expected_report.json
+++ b/src/test/resources/__files/expected_report.json
@@ -1,92 +1,255 @@
-[
-  {
-    "packageRef": {
-      "name": "org.postgresql:postgresql",
-      "version": "45.0.5"
-    },
-    "transitive": [
-      {
-        "packageRef": {
-
-        },
-        "issues": [],
-        "recommendations": []
-      }
-    ],
-    "issues": [
-      {
-        "id": "SNYK-JAVA-IONETTY-1070799",
-        "source": "snyk",
-        "rawData": {
-          "id": "SNYK-JAVA-IONETTY-1070799",
-          "title": "Information Disclosure",
-          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-          "credit": [
-            "Jonathan Leitschuh"
-          ],
-          "semver": {
-            "vulnerable": [
-              "[4.0.0.Final, 4.1.59.Final)"
-            ]
-          },
-          "fixedIn": [
-            "4.1.59.Final"
-          ],
-          "insights": {
-            "triageAdvice": "This vulnerability is only applicable on Linux operating systems"
-          },
-          "language": "java",
-          "severity": "medium",
-          "cvssScore": 6.2,
-          "moduleName": "io.netty:netty-codec-http",
-          "cvssDetails": [
-            {
-              "assigner": "Red Hat",
-              "severity": "medium",
-              "cvssV3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
-              "cvssV3BaseScore": 6.2,
-              "modificationTime": "2023-03-26T14:47:50.011213Z"
-            },
-            {
-              "assigner": "NVD",
-              "severity": "medium",
-              "cvssV3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
-              "cvssV3BaseScore": 5.5,
-              "modificationTime": "2022-05-13T01:10:58.276413Z"
-            }
-          ],
-          "description": "## Overview\n[io.netty:netty-codec-http](https://mvnrepository.com/artifact/io.netty/netty-codec-http) is a network application framework for rapid development of maintainable high performance protocol servers & clients.\nAffected versions of this package are vulnerable to Information Disclosure via the `AbstractDiskHttpData` method, and on Unix-like systems.\r\n\r\nWhen `netty`'s multipart decoders are used, local information disclosure can occur via the local system temporary directory if temporary storing uploads on the disk are enabled.\r\nOn unix-like systems, the temporary directory is shared between all users. As such, writing to this directory using API's that do not explicitly set the file/directory permissions can lead to information disclosure.\r\nThe method `File.createTempFile` on unix-like systems creates a random file, but, by default will create this file with the permissions `-rw-r--r--`. Sensitive information is written to this file in `AbstractDiskHttpData`, and other local users can read it.\n## Remediation\nUpgrade `io.netty:netty-codec-http` to version 4.1.59.Final or higher.\n## References\n- [GitHub Commit](https://github.com/netty/netty/commit/c735357bf29d07856ad171c6611a2e1a0e0000ec)\n",
-          "identifiers": {
-            "CVE": [
-              "CVE-2021-21290"
-            ],
-            "CWE": [
-              "CWE-378"
-            ],
-            "GHSA": [
-              "GHSA-5mcr-gq6c-3hq2"
-            ]
-          },
-          "packageName": "io.netty:netty-codec-http",
-          "proprietary": false,
-          "disclosureTime": "2021-02-09T09:57:33Z",
-          "packageManager": "maven",
-          "mavenModuleName": {
-            "groupId": "io.netty",
-            "artifactId": "netty-codec-http"
-          }
-        }
-      }
-    ],
-    "recommendations": [
-      {
-        "id": "CVE-2021-21290",
-        "status": "fixed",
-        "package": {
-          "name": "io.quarkus:quarkus-jdbc-postgresql",
-          "version": "1.2.3-redhat-0002"
-        }
-      }
-    ]
-  }
-]
+{
+	"summary": {
+		"dependencies": {
+			"scanned": 2,
+			"transitive": 7
+		},
+		"vulnerabilities": {
+			"total": 4,
+			"direct": 2,
+			"critical": 0,
+			"high": 1,
+			"medium": 3,
+			"low": 0
+		}
+	},
+	"dependencies": [{
+		"ref": {
+			"name": "io.quarkus:quarkus-hibernate-orm",
+			"version": "2.13.5.Final"
+		},
+		"highestVulnerability": {
+			"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+			"title": "Denial of Service (DoS)",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Network",
+				"attackComplexity": "Low",
+				"privilegesRequired": "None",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "None",
+				"integrityImpact": "None",
+				"availabilityImpact": "High",
+				"exploitCodeMaturity": null,
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+			},
+			"cvssScore": 7.5,
+			"severity": "HIGH",
+			"cves": ["CVE-2020-36518"],
+			"unique": false
+		},
+		"issues": [],
+		"transitive": [{
+			"ref": {
+				"name": "com.fasterxml.jackson.core:jackson-databind",
+				"version": "2.13.1"
+			},
+			"highestVulnerability": {
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "Low",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+				},
+				"cvssScore": 7.5,
+				"severity": "HIGH",
+				"cves": ["CVE-2020-36518"],
+				"unique": false
+			},
+			"issues": [{
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "Low",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+				},
+				"cvssScore": 7.5,
+				"severity": "HIGH",
+				"cves": ["CVE-2020-36518"],
+				"unique": false
+			}, {
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "High",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": "Proof of concept code",
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+				},
+				"cvssScore": 5.9,
+				"severity": "MEDIUM",
+				"cves": [],
+				"unique": true
+			}, {
+				"id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426",
+				"title": "Denial of Service (DoS)",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Network",
+					"attackComplexity": "High",
+					"privilegesRequired": "None",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "None",
+					"integrityImpact": "None",
+					"availabilityImpact": "High",
+					"exploitCodeMaturity": "Proof of concept code",
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P"
+				},
+				"cvssScore": 5.9,
+				"severity": "MEDIUM",
+				"cves": ["CVE-2022-42003"],
+				"unique": false
+			}],
+			"remediations": {
+				"CVE-2022-42003": {
+					"issueRef": "CVE-2022-42003",
+					"mavenPackage": {
+						"name": "com.fasterxml.jackson.core:jackson-databind",
+						"version": "2.13.1.Final-redhat-00002"
+					},
+					"productStatus": "known_not_affected"
+				},
+				"CVE-2020-36518": {
+					"issueRef": "CVE-2020-36518",
+					"mavenPackage": {
+						"name": "com.fasterxml.jackson.core:jackson-databind",
+						"version": "2.13.1.Final-redhat-00002"
+					},
+					"productStatus": "known_affected"
+				}
+			}
+		}],
+		"remediations": {},
+		"recommendation": null
+	}, {
+		"ref": {
+			"name": "io.quarkus:quarkus-jdbc-postgresql",
+			"version": "2.13.5.Final"
+		},
+		"highestVulnerability": {
+			"id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
+			"title": "Information Exposure",
+			"source": "snyk",
+			"cvss": {
+				"attackVector": "Local",
+				"attackComplexity": "High",
+				"privilegesRequired": "Low",
+				"userInteraction": "None",
+				"scope": "Unchanged",
+				"confidentialityImpact": "High",
+				"integrityImpact": "None",
+				"availabilityImpact": "None",
+				"exploitCodeMaturity": null,
+				"remediationLevel": null,
+				"reportConfidence": null,
+				"cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+			},
+			"cvssScore": 4.7,
+			"severity": "MEDIUM",
+			"cves": ["CVE-2022-41946"],
+			"unique": false
+		},
+		"issues": [],
+		"transitive": [{
+			"ref": {
+				"name": "org.postgresql:postgresql",
+				"version": "42.5.0"
+			},
+			"highestVulnerability": {
+				"id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
+				"title": "Information Exposure",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Local",
+					"attackComplexity": "High",
+					"privilegesRequired": "Low",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "High",
+					"integrityImpact": "None",
+					"availabilityImpact": "None",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+				},
+				"cvssScore": 4.7,
+				"severity": "MEDIUM",
+				"cves": ["CVE-2022-41946"],
+				"unique": false
+			},
+			"issues": [{
+				"id": "SNYK-JAVA-ORGPOSTGRESQL-3146847",
+				"title": "Information Exposure",
+				"source": "snyk",
+				"cvss": {
+					"attackVector": "Local",
+					"attackComplexity": "High",
+					"privilegesRequired": "Low",
+					"userInteraction": "None",
+					"scope": "Unchanged",
+					"confidentialityImpact": "High",
+					"integrityImpact": "None",
+					"availabilityImpact": "None",
+					"exploitCodeMaturity": null,
+					"remediationLevel": null,
+					"reportConfidence": null,
+					"cvss": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N"
+				},
+				"cvssScore": 4.7,
+				"severity": "MEDIUM",
+				"cves": ["CVE-2022-41946"],
+				"unique": false
+			}],
+			"remediations": {
+				"CVE-2022-41946": {
+					"issueRef": "CVE-2022-41946",
+					"mavenPackage": {
+						"name": "io.quarkus:quarkus-jdbc-postgresql",
+						"version": "2.13.7.Final-redhat-00003"
+					},
+					"productStatus": "fixed"
+				}
+			}
+		}],
+		"remediations": {},
+		"recommendation": null
+	}]
+}

--- a/src/test/resources/__files/full_report_no_token.html
+++ b/src/test/resources/__files/full_report_no_token.html
@@ -222,16 +222,17 @@
                         </div>
                     </td>
                     <td>
-                        <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244"
-                           target="_blank">
-                            SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244
-                        </a>
+                            <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244"
+                            target="_blank">
+                                SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244
+                            </a>
+                        
                     </td>
                 <td>
                             <div>
                                 <svg style="width: 10.9793322px; height: 13px" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                     <use href="#shield-icon"/>
-                                </svg> 2 Transitive
+                                </svg> 1 Transitive
                             </div>
                 </td>
             </tr>
@@ -252,20 +253,21 @@
                                 <tr>
                                     <th scope="col" style="width: 21%">Dependencies</th>
                                     <th scope="col">Severity</th>
+                                    <th scope="col" style="width: 18%">Exploit Maturity</th>
                                     <th scope="col">Description</th>
-                                    <th scope="col" style="width: 15%">CVSS</th>
+                                    <th scope="col" style="width: 13%">CVSS</th>
                                     <th scope="col">CVE</th>
                                     <th scope="col">Remediation</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                             <tr>
-                                                    <td rowspan="3">
-                                                        <a href="https://security.snyk.io/package/maven/com.fasterxml.jackson.core:jackson-databind"
-                                                           target="_blank">
-                                                            com.fasterxml.jackson.core:jackson-databind
-                                                        </a>
-                                                    </td>
+                                                <td rowspan="3">
+                                                    <a href="https://security.snyk.io/package/maven/com.fasterxml.jackson.core:jackson-databind"
+                                                        target="_blank">
+                                                        com.fasterxml.jackson.core:jackson-databind
+                                                    </a>
+                                                </td>
                                                 <td style="padding-left: 0.5rem">
                                                     <span class="pf-c-label pf-m-red">
                                                             <span class="pf-c-label__content">
@@ -273,6 +275,7 @@
                                                             </span>
                                                         </span>
                                                 </td>
+                                                <td>No known exploit</td>
                                                 <td>Denial of Service (DoS)</td>
                                                 <td>
                                                     <div class="pf-c-progress pf-m-danger" id="progress-simple-example">
@@ -304,14 +307,11 @@
                                                 </td>
                                             </tr>
                                             <tr>
-                                                <td style="padding-left: 0.5rem">
-                                                            <span class="pf-c-label pf-m-orange">
-                                                            <span class="pf-c-label__content">
-                                                                medium
-                                                            </span>
-                                                        </span>
+                                                <td colspan="3"><a href="https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9"
+                                                        target="_blank">
+                                                        Sign up for a free Snyk account
+                                                    </a>to find out which vulnerabilities have a publicly known exploits
                                                 </td>
-                                                <td>Denial of Service (DoS)</td>
                                                 <td>
                                                         <div class="pf-c-progress pf-m-warning" id="progress-simple-example">
                                                             <div class="pf-c-progress__description" id="progress-simple-example-description"
@@ -330,15 +330,12 @@
                                                     </div>
                                                 </td>
                                                 <td>
-                                                            CVE-2022-42004
                                                 </td>
                                                 <td>
-                                                        <svg style="width: 10.9793322px; height: 13px" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                                                            <use href="#shield-icon"/>
-                                                        </svg>
-                                                        <button type="button" class="btn btn-link" data-toggle="modal" data-target="#modal" data-vex="https://tc-storage-mvp.s3.amazonaws.com/vexes/CVE-2022-42004-Quarkus.json" data-sbom="https://tc-storage-mvp.s3.amazonaws.com/sboms/sbom.json" data-link="https://maven.repository.redhat.com/ga/com/fasterxml/jackson/core/jackson-databind/2.13.1.Final-redhat-00002" data-rhpkg="2.13.1.Final-redhat-00002">
-                                                            2.13.1.Final-redhat-00002
-                                                        </button>
+                                                            <a href="https://app.snyk.io/login?utm_campaign=Code-Ready-Analytics-2020&utm_source=code_ready&code_ready=FF1B53D9-57BE-4613-96D7-1D06066C38C9"
+                                                                target="_blank">
+                                                                Sign up for a free Snyk account
+                                                            </a>to learn about the vulnerabilities found
                                                 </td>
                                             </tr>
                                             <tr>
@@ -349,6 +346,7 @@
                                                             </span>
                                                         </span>
                                                 </td>
+                                                <td>Proof of concept code</td>
                                                 <td>Denial of Service (DoS)</td>
                                                 <td>
                                                         <div class="pf-c-progress pf-m-warning" id="progress-simple-example">
@@ -371,10 +369,10 @@
                                                             CVE-2022-42003
                                                 </td>
                                                 <td>
-                                                        <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426"
-                                                           target="_blank">
-                                                            SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426
-                                                        </a>
+                                                            <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426"
+                                                            target="_blank">
+                                                                SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426
+                                                            </a>
                                                 </td>
                                             </tr>
                                 </tbody>
@@ -418,10 +416,11 @@
                         </div>
                     </td>
                     <td>
-                        <a href="https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-3146847?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-ORGPOSTGRESQL-3146847"
-                           target="_blank">
-                            SNYK-JAVA-ORGPOSTGRESQL-3146847
-                        </a>
+                            <a href="https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-3146847?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-ORGPOSTGRESQL-3146847"
+                            target="_blank">
+                                SNYK-JAVA-ORGPOSTGRESQL-3146847
+                            </a>
+                        
                     </td>
                 <td>
                             <div>
@@ -448,20 +447,21 @@
                                 <tr>
                                     <th scope="col" style="width: 21%">Dependencies</th>
                                     <th scope="col">Severity</th>
+                                    <th scope="col" style="width: 18%">Exploit Maturity</th>
                                     <th scope="col">Description</th>
-                                    <th scope="col" style="width: 15%">CVSS</th>
+                                    <th scope="col" style="width: 13%">CVSS</th>
                                     <th scope="col">CVE</th>
                                     <th scope="col">Remediation</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                             <tr>
-                                                    <td rowspan="1">
-                                                        <a href="https://security.snyk.io/package/maven/org.postgresql:postgresql"
-                                                           target="_blank">
-                                                            org.postgresql:postgresql
-                                                        </a>
-                                                    </td>
+                                                <td rowspan="1">
+                                                    <a href="https://security.snyk.io/package/maven/org.postgresql:postgresql"
+                                                        target="_blank">
+                                                        org.postgresql:postgresql
+                                                    </a>
+                                                </td>
                                                 <td style="padding-left: 0.5rem">
                                                             <span class="pf-c-label pf-m-orange">
                                                             <span class="pf-c-label__content">
@@ -469,6 +469,7 @@
                                                             </span>
                                                         </span>
                                                 </td>
+                                                <td>No known exploit</td>
                                                 <td>Information Exposure</td>
                                                 <td>
                                                         <div class="pf-c-progress pf-m-warning" id="progress-simple-example">

--- a/src/test/resources/__files/full_report_token.html
+++ b/src/test/resources/__files/full_report_token.html
@@ -1,0 +1,564 @@
+<svg version="1.1" style="display: none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <symbol viewBox="0 0 10.9793322 13"id="shield-icon">
+        <title>Combined Shape</title>
+        <g id="New-dependencies-view" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <g id="Overview" transform="translate(-1207.172757, -938.000000)" fill="#3E8635">
+                <g id="Details-of-dependency-com.github" transform="translate(427.000000, 764.000000)">
+                    <g id="Dependency-1" transform="translate(0.000000, 144.000000)">
+                        <g id="Group-9" transform="translate(780.172757, 24.000000)">
+                            <g id="Group-4" transform="translate(0.000000, 3.200001)">
+                                <g id="Icons/2.-Size-sm/Actions/check" transform="translate(0.000000, 2.799999)">
+                                    <path d="M10.5565789,0 C10.7906249,0 10.9793322,0.181542969 10.9793322,0.40625 L10.9793322,5.74082031 C10.9793322,9.75 6.24081907,13 5.49579296,13 C4.75076684,13 0,9.75 0,5.73955078 L0,0.40625 C0,0.181542969 0.188707272,0 0.422753304,0 Z M8.54277883,3.11782667 L4.7912961,6.89087353 L3.03981338,5.1293244 C2.883609,4.97220683 2.63032812,4.97220683 2.47412375,5.1293244 L1.90844938,5.69826556 C1.75224501,5.85538312 1.75224501,6.11010449 1.90844938,6.26720671 L4.50845797,8.88215991 C4.66464708,9.03927747 4.9179127,9.03927747 5.07413233,8.88217525 L9.67414282,4.25570898 C9.8303472,4.09859141 9.8303472,3.84387004 9.67414282,3.68676782 L9.10846846,3.11782667 C8.95226408,2.96072444 8.6989832,2.96072444 8.54277883,3.11782667 Z" id="Combined-Shape"></path>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </symbol>
+</svg>
+<html xmlns="http://www.w3.org/1999/html">
+<head>
+<style type="text/css">
+    * {box-sizing: border-box}
+
+    /* Set height of body and the document to 100% */
+    body, html {
+        height: 100%;
+        margin: 0;
+        font-family: Arial;
+        padding: 20px;
+    }
+    .pf-c-table thead,
+    .pf-c-table .pf-m-truncate {
+        --pf-c-table--cell--MaxWidth: none !important;
+    }
+    .hiddenRow {
+        padding: 0 !important;
+    }
+    .accordion {
+        background-color: #eee;
+        /*color: #444;*/
+        color:#06c;
+
+        cursor: pointer;
+        padding: 18px;
+        width: 100%;
+        border: none;
+        text-align: left;
+        outline: none;
+        font-size: 15px;
+        transition: 0.4s;
+    }
+
+    .active, .accordion:hover {
+        background-color: #ccc;
+    }
+
+    .accordion:after {
+        content: '\002B';
+        color: #777;
+        font-weight: bold;
+        float: right;
+        margin-left: 5px;
+    }
+
+    .active:after {
+        content: "\2212";
+    }
+
+    .panel {
+        padding: 0 18px;
+        background-color: white;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.2s ease-out;
+    }
+    .panel2 {
+        padding: 0 18px;
+        display: none;
+        background-color: white;
+        overflow: hidden;
+    }
+
+    /* Style tab links */
+    .tablink {
+        background-color: #555;
+        color: white;
+        float: left;
+        border: none;
+        outline: none;
+        cursor: pointer;
+        padding: 14px 16px;
+        font-size: 17px;
+        width: 25%;
+    }
+
+    .tablink:hover {
+        background-color: #777;
+    }
+
+    /* Style the tab content (and add height:100% for full page content) */
+    .tabcontent {
+        color: black;
+        display: none;
+        padding: 100px 20px;
+        height: fit-content;
+    }
+
+    /*#redhat {background-color: red;}*/
+    /*#snyk {background-color: lightgreen;}*/
+    /*#tidelift {background-color: lightskyblue;}*/
+</style>    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet" href="fonts.css"/>
+    <!-- Include latest PatternFly CSS via CDN -->
+    <link
+            rel="stylesheet"
+            href="https://unpkg.com/@patternfly/patternfly/patternfly.css"
+            crossorigin="anonymous"
+    />
+    <link rel="stylesheet" href="style.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css"
+          integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+    <title>CRDA Dependency Analysis</title>
+</head>
+<body class="p-4 container-fluid">
+
+<div class="card">
+    <div class="card-header">
+        <span class="pf-c-icon">
+          <span class="pf-c-icon__content pf-m-warning">
+            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+          </span>
+        </span>
+        <span style="font-size: larger">&nbsp; Security Issues</span>
+
+    </div>
+    <div class="card-body">
+        <div class="row" >
+            <div class="col-5">
+                <p>Below is a list of dependencies affected with CVE, as well as vulnerability only found using Snyk's vulnerability database.</p>
+            </div>
+            <div class="col offset-1">
+                <p style="font-size: larger">Dependencies with security issues in your stack.</p>
+                <p>Dependencies with high common vulnerabilities and exposures (CVE) score.</p>
+                <p class="ml-5">
+                    <span class="pf-c-icon pf-m-sm">
+                      <span class="pf-c-icon__content pf-m-info">
+                          <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
+                      </span>
+                    </span>
+                    Total Vulnerabilities: 4
+                </p>
+                <p class="ml-5">
+                    <span class="pf-c-icon pf-m-sm">
+                      <span class="pf-c-icon__content pf-m-warning">
+                        <i class="pf-icon pf-icon-security" aria-hidden="true"></i>
+                      </span>
+                    </span>
+                    Vulnerable Dependencies: 2
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="ml-3 mt-4">
+    <div class="d-inline p-2 bg-light">Commonly Known Vulnerabilities</div>
+</div>
+<div>
+    <hr class="pf-c-divider mt-2"/>
+</div>
+
+<div class="p-3">
+    <table class="pf-c-table pf-m-expandable pf-m-compact pf-m-grid-md">
+        <thead class="">
+        <tr>
+            <th role="columnheader" scope="col"></th>
+            <th role="columnheader" scope="col">#</th>
+            <th role="columnheader" scope="col">Dependencies</th>
+            <th role="columnheader" scope="col"># Direct</th>
+            <th role="columnheader" scope="col"># Transitive</th>
+            <th role="columnheader" scope="col">Highest CVSS</th>
+            <th role="columnheader" scope="col">Highest Severity</th>
+            <th role="columnheader" scope="col">Red Hat remediation available</th>
+        </tr>
+        </thead>
+        <tbody>
+            <tr data-toggle="collapse" data-target="#ioquarkusquarkushibernateorm" class="accordion-toggle">
+                <td role="cell">
+                    <div class="pf-c-table__toggle-icon">
+                        <i class="fas fa-angle-down" aria-hidden="true"></i>
+                    </div>
+                </td>
+                <td>#1</td>
+                <td>
+                    <a href="https://security.snyk.io/package/maven/io.quarkus:quarkus-hibernate-orm"
+                       target="_blank">
+                        io.quarkus:quarkus-hibernate-orm
+                    </a>
+                </td>
+                <td>0</td>
+                <td>3</td>
+                    <td>
+                        <div class="pf-c-progress pf-m-danger" id="progress-simple-example">
+                                <div
+                                        class="pf-c-progress__description"
+                                        id="progress-simple-example-description"
+                                >7.5/10</div>
+                                <div
+                                        class="pf-c-progress__bar"
+                                        role="progressbar"
+                                        aria-valuemin="0"
+                                        aria-valuemax="10"
+                                        aria-valuenow="7.5"
+                                        aria-labelledby="progress-simple-example-description"
+                                >
+                                    <div class="pf-c-progress__indicator" style="width:75%;"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                    <td>
+                            <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244"
+                            target="_blank">
+                                SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244
+                            </a>
+                        
+                    </td>
+                <td>
+                            <div>
+                                <svg style="width: 10.9793322px; height: 13px" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                    <use href="#shield-icon"/>
+                                </svg> 1 Transitive
+                            </div>
+                </td>
+            </tr>
+            <tr class="pf-c-table__expandable-row pf-m-expanded">
+                <td colspan="8" class="hiddenRow">
+                    <div class="accordion-body collapse p-4 bg-light" id="ioquarkusquarkushibernateorm">
+                        <p class="px-3">Details of the dependency:
+                            <span class="font-weight-bold">io.quarkus:quarkus-hibernate-orm</span>
+                        </p>
+                        <button type="button" class="btn btn-outline-secondary" data-toggle="collapse" style="font-size: small;"
+                                href="#ioquarkusquarkushibernateormtransTable" role="button" aria-expanded="false"
+                                aria-controls="ioquarkusquarkushibernateormtransTable">
+                            Transitive Dependencies with vulnerabilites <i class="fa fa-angle-down"></i>
+                        </button>
+                        <div class="p-3 collapse" id="ioquarkusquarkushibernateormtransTable">
+                            <table class="pf-c-table pf-m-expandable pf-m-compact pf-m-grid-md">
+                                <thead>
+                                <tr>
+                                    <th scope="col" style="width: 21%">Dependencies</th>
+                                    <th scope="col">Severity</th>
+                                    <th scope="col" style="width: 18%">Exploit Maturity</th>
+                                    <th scope="col">Description</th>
+                                    <th scope="col" style="width: 13%">CVSS</th>
+                                    <th scope="col">CVE</th>
+                                    <th scope="col">Remediation</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                            <tr>
+                                                <td rowspan="3">
+                                                    <a href="https://security.snyk.io/package/maven/com.fasterxml.jackson.core:jackson-databind"
+                                                        target="_blank">
+                                                        com.fasterxml.jackson.core:jackson-databind
+                                                    </a>
+                                                </td>
+                                                <td style="padding-left: 0.5rem">
+                                                    <span class="pf-c-label pf-m-red">
+                                                            <span class="pf-c-label__content">
+                                                                high
+                                                            </span>
+                                                        </span>
+                                                </td>
+                                                <td>No known exploit</td>
+                                                <td>Denial of Service (DoS)</td>
+                                                <td>
+                                                    <div class="pf-c-progress pf-m-danger" id="progress-simple-example">
+                                                            <div class="pf-c-progress__description" id="progress-simple-example-description"
+                                                            >7.5/10</div>
+                                                            <div
+                                                                    class="pf-c-progress__bar"
+                                                                    role="progressbar"
+                                                                    aria-valuemin="0"
+                                                                    aria-valuemax="10"
+                                                                    aria-valuenow="7.5"
+                                                                    aria-labelledby="progress-simple-example-description"
+                                                            >
+                                                                <div class="pf-c-progress__indicator" style="width:75%;"></div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                            CVE-2020-36518
+                                                </td>
+                                                <td>
+                                                        <svg style="width: 10.9793322px; height: 13px" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                                            <use href="#shield-icon"/>
+                                                        </svg>
+                                                        <button type="button" class="btn btn-link" data-toggle="modal" data-target="#modal" data-vex="https://tc-storage-mvp.s3.amazonaws.com/vexes/CVE-2020-36518-Quarkus.json" data-sbom="https://tc-storage-mvp.s3.amazonaws.com/sboms/sbom.json" data-link="https://maven.repository.redhat.com/ga/com/fasterxml/jackson/core/jackson-databind/2.13.1.Final-redhat-00002" data-rhpkg="2.13.1.Final-redhat-00002">
+                                                            2.13.1.Final-redhat-00002
+                                                        </button>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding-left: 0.5rem">
+                                                            <span class="pf-c-label pf-m-orange">
+                                                            <span class="pf-c-label__content">
+                                                                medium
+                                                            </span>
+                                                        </span>
+                                                </td>
+                                                <td>Proof of concept code</td>
+                                                <td>Denial of Service (DoS)</td>
+                                                <td>
+                                                        <div class="pf-c-progress pf-m-warning" id="progress-simple-example">
+                                                            <div class="pf-c-progress__description" id="progress-simple-example-description"
+                                                            >5.9/10</div>
+                                                            <div
+                                                                    class="pf-c-progress__bar"
+                                                                    role="progressbar"
+                                                                    aria-valuemin="0"
+                                                                    aria-valuemax="10"
+                                                                    aria-valuenow="5.9"
+                                                                    aria-labelledby="progress-simple-example-description"
+                                                            >
+                                                                <div class="pf-c-progress__indicator" style="width:59%;"></div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                </td>
+                                                <td>
+                                                            <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424"
+                                                            target="_blank">
+                                                                SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424
+                                                            </a>
+                                                </td>
+                                            </tr>
+                                            <tr>
+                                                <td style="padding-left: 0.5rem">
+                                                            <span class="pf-c-label pf-m-orange">
+                                                            <span class="pf-c-label__content">
+                                                                medium
+                                                            </span>
+                                                        </span>
+                                                </td>
+                                                <td>Proof of concept code</td>
+                                                <td>Denial of Service (DoS)</td>
+                                                <td>
+                                                        <div class="pf-c-progress pf-m-warning" id="progress-simple-example">
+                                                            <div class="pf-c-progress__description" id="progress-simple-example-description"
+                                                            >5.9/10</div>
+                                                            <div
+                                                                    class="pf-c-progress__bar"
+                                                                    role="progressbar"
+                                                                    aria-valuemin="0"
+                                                                    aria-valuemax="10"
+                                                                    aria-valuenow="5.9"
+                                                                    aria-labelledby="progress-simple-example-description"
+                                                            >
+                                                                <div class="pf-c-progress__indicator" style="width:59%;"></div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                            CVE-2022-42003
+                                                </td>
+                                                <td>
+                                                            <a href="https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426"
+                                                            target="_blank">
+                                                                SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426
+                                                            </a>
+                                                </td>
+                                            </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            <tr data-toggle="collapse" data-target="#ioquarkusquarkusjdbcpostgresql" class="accordion-toggle">
+                <td role="cell">
+                    <div class="pf-c-table__toggle-icon">
+                        <i class="fas fa-angle-down" aria-hidden="true"></i>
+                    </div>
+                </td>
+                <td>#2</td>
+                <td>
+                    <a href="https://security.snyk.io/package/maven/io.quarkus:quarkus-jdbc-postgresql"
+                       target="_blank">
+                        io.quarkus:quarkus-jdbc-postgresql
+                    </a>
+                </td>
+                <td>0</td>
+                <td>1</td>
+                    <td>
+                            <div class="pf-c-progress pf-m-warning" id="progress-simple-example">
+                                <div
+                                        class="pf-c-progress__description"
+                                        id="progress-simple-example-description"
+                                >4.7/10</div>
+                                <div
+                                        class="pf-c-progress__bar"
+                                        role="progressbar"
+                                        aria-valuemin="0"
+                                        aria-valuemax="10"
+                                        aria-valuenow="4.7"
+                                        aria-labelledby="progress-simple-example-description"
+                                >
+                                    <div class="pf-c-progress__indicator" style="width:47%;"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </td>
+                    <td>
+                            <a href="https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-3146847?utm_medium=Partner&utm_source=RedHat&utm_campaign=Code-Ready-Analytics-2020&utm_content=vuln/SNYK-JAVA-ORGPOSTGRESQL-3146847"
+                            target="_blank">
+                                SNYK-JAVA-ORGPOSTGRESQL-3146847
+                            </a>
+                        
+                    </td>
+                <td>
+                            <div>
+                                <svg style="width: 10.9793322px; height: 13px" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                    <use href="#shield-icon"/>
+                                </svg> 1 Transitive
+                            </div>
+                </td>
+            </tr>
+            <tr class="pf-c-table__expandable-row pf-m-expanded">
+                <td colspan="8" class="hiddenRow">
+                    <div class="accordion-body collapse p-4 bg-light" id="ioquarkusquarkusjdbcpostgresql">
+                        <p class="px-3">Details of the dependency:
+                            <span class="font-weight-bold">io.quarkus:quarkus-jdbc-postgresql</span>
+                        </p>
+                        <button type="button" class="btn btn-outline-secondary" data-toggle="collapse" style="font-size: small;"
+                                href="#ioquarkusquarkusjdbcpostgresqltransTable" role="button" aria-expanded="false"
+                                aria-controls="ioquarkusquarkusjdbcpostgresqltransTable">
+                            Transitive Dependencies with vulnerabilites <i class="fa fa-angle-down"></i>
+                        </button>
+                        <div class="p-3 collapse" id="ioquarkusquarkusjdbcpostgresqltransTable">
+                            <table class="pf-c-table pf-m-expandable pf-m-compact pf-m-grid-md">
+                                <thead>
+                                <tr>
+                                    <th scope="col" style="width: 21%">Dependencies</th>
+                                    <th scope="col">Severity</th>
+                                    <th scope="col" style="width: 18%">Exploit Maturity</th>
+                                    <th scope="col">Description</th>
+                                    <th scope="col" style="width: 13%">CVSS</th>
+                                    <th scope="col">CVE</th>
+                                    <th scope="col">Remediation</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                            <tr>
+                                                <td rowspan="1">
+                                                    <a href="https://security.snyk.io/package/maven/org.postgresql:postgresql"
+                                                        target="_blank">
+                                                        org.postgresql:postgresql
+                                                    </a>
+                                                </td>
+                                                <td style="padding-left: 0.5rem">
+                                                            <span class="pf-c-label pf-m-orange">
+                                                            <span class="pf-c-label__content">
+                                                                medium
+                                                            </span>
+                                                        </span>
+                                                </td>
+                                                <td>No known exploit</td>
+                                                <td>Information Exposure</td>
+                                                <td>
+                                                        <div class="pf-c-progress pf-m-warning" id="progress-simple-example">
+                                                            <div class="pf-c-progress__description" id="progress-simple-example-description"
+                                                            >4.7/10</div>
+                                                            <div
+                                                                    class="pf-c-progress__bar"
+                                                                    role="progressbar"
+                                                                    aria-valuemin="0"
+                                                                    aria-valuemax="10"
+                                                                    aria-valuenow="4.7"
+                                                                    aria-labelledby="progress-simple-example-description"
+                                                            >
+                                                                <div class="pf-c-progress__indicator" style="width:47%;"></div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                                <td>
+                                                            CVE-2022-41946
+                                                </td>
+                                                <td>
+                                                        <svg style="width: 10.9793322px; height: 13px" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                                            <use href="#shield-icon"/>
+                                                        </svg>
+                                                        <button type="button" class="btn btn-link" data-toggle="modal" data-target="#modal" data-vex="https://tc-storage-mvp.s3.amazonaws.com/vexes/CVE-2022-41946-Quarkus.json" data-sbom="https://tc-storage-mvp.s3.amazonaws.com/sboms/sbom.json" data-link="https://maven.repository.redhat.com/ga/io/quarkus/quarkus-jdbc-postgresql/2.13.7.Final-redhat-00003" data-rhpkg="2.13.7.Final-redhat-00003">
+                                                            2.13.7.Final-redhat-00003
+                                                        </button>
+                                                </td>
+                                            </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<!-- Modal -->
+<div class="modal fade" id="modal" tabindex="-1" aria-labelledby="modalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalLabel">
+                    <a href="" target="_blank">
+                        Modal title
+                    </a>
+                </h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                Click either VEX or SBOM to download the corresponding file type. You can also click the package name to view more information in Red Hat's Maven repository.
+            </div>
+            <div class="modal-footer" style="justify-content: space-around">
+                <span id="vex"><a href="" target="_blank">VEX</a></span>
+                <span id="sbom"> <a href="" target="_blank">SBOMs</a></span>
+            </div>
+        </div>
+    </div>
+</div>
+
+</div>
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+        integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+        crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+        crossorigin="anonymous"></script>
+<script>
+    $('#modal').on('show.bs.modal', function (event) {
+        var button = $(event.relatedTarget) // Button that triggered the modal
+        var link = button.data('link')// Extract info from data-* attributes
+        var rhpkg = button.data('rhpkg')
+        var vex = button.data('vex')
+        var sbom = button.data('sbom')
+        var modal = $(this)
+        modal.find('.modal-title a').attr("href", link);
+        modal.find('.modal-title a').text(rhpkg);
+        modal.find('#vex a').attr("href", vex)
+        modal.find('#sbom a').attr("href", sbom)
+    })
+</script>
+</body>
+</html>

--- a/src/test/resources/__files/snyk_report.json
+++ b/src/test/resources/__files/snyk_report.json
@@ -129,7 +129,6 @@
           },
           "identifiers": {
               "CVE": [
-                  "CVE-2022-42004"
               ],
               "CWE": [
                   "CWE-400"
@@ -321,7 +320,7 @@
       }
   ],
   "org": {
-      "id": "bec5d7b5-5168-4b9f-a53f-834f1433437b",
-      "name": "rubens-playground"
+      "id": "abcd-efgh-0123-4567",
+      "name": "example-org"
   }
 }

--- a/src/test/resources/__files/trustedContent_vex_report.json
+++ b/src/test/resources/__files/trustedContent_vex_report.json
@@ -15,14 +15,6 @@
     },
     "productStatus": "known_affected"
   },
-  {
-    "mavenPackage": {
-        "artifactId": "jackson-databind",
-        "groupId": "com.fasterxml.jackson.core",
-        "version": "2.13.1.Final-redhat-00002"
-    },
-    "productStatus": "known_not_affected"
-  },
   null,
   null
 ]


### PR DESCRIPTION
Verbose mode helps retrieving only the summary for the JSON report.
When clients do not provide a token for the vulnerability provider data will be limited in both the JSON and HTML reports.