### PR TITLE
chore: removed unexpected properties from openapi spec

### DIFF
--- a/src/main/resources/META-INF/openapi.yaml
+++ b/src/main/resources/META-INF/openapi.yaml
@@ -105,11 +105,6 @@ paths:
                     $ref: '#/components/schemas/AnalysisReport'
                   html_report:
                     type: object
-              encoding:
-                summary:
-                  contentType: application/json
-                report:
-                  contentType: text/html
 components:
   schemas:
     AnalysisReport:


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

We generate types from the openapi spec in this repo. While generating for [crda-java-api](https://github.com/RHEcosystemAppEng/crda-java-api), I bumped into the following message:
```
org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 2, Warning count: 0
Errors:
        -attribute paths.'/dependency-analysis/{pkgManager}'(post).responses.200.content.'multipart/mixed'.encoding.report is unexpected
        -attribute paths.'/dependency-analysis/{pkgManager}'(post).responses.200.content.'multipart/mixed'.encoding.summary is unexpected
```

These properties removal doesn't seem to affect the types generation.

