### PR TITLE
Add token validation endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,11 @@
-name: Integration Test
+name: Validation
 on:
   workflow_dispatch:
   pull_request:
 jobs:
-  build:
+  integration-tests:
     runs-on: ubuntu-latest
+    name: Integration Tests
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -18,3 +19,22 @@ jobs:
       - name: Run integration tests
         run: |
           ./mvnw verify -Pnative
+  openapi-lint-checks:
+    runs-on: ubuntu-latest
+    name: OpenAPI Linter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npx @redocly/cli lint src/main/resources/META-INF/openapi.yaml
+  openapi-validation:
+    runs-on: ubuntu-latest
+    name: Validate OpenAPI Spec
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate OpenAPI definition
+        uses: char0n/swagger-editor-validate@v1
+        with:
+          definition-file: src/main/resources/META-INF/openapi.yaml

--- a/README.md
+++ b/README.md
@@ -215,6 +215,25 @@ $ curl 'http://localhost:8080/api/v3/component-analysis/maven' \
 }
 ```
 
+## Token validation
+
+Clients are allowed to validate the vulnerability provider token with a specific endpoint. That will allow IDEs and the CLI to persist the different
+tokens and validate them when saving them.
+
+The request will be a GET to the `/token` path containing the HTTP header with the token. The header format will follow the same rules as for the
+other HTTP requests. i.e. `crda-<provider>-token`
+
+```bash
+http -v :8080/api/v3/token crda-snyk-token==example-token
+```
+
+The possible responses are:
+
+- 200 - Token validated successfully
+- 400 - Missing authentication header
+- 401 - Invalid auth token provided
+- 500 - Server error
+
 ## Deploy on OpenShift
 
 The required parameters can be injected as environment variables through a secret. Create the `crda-secret` Secret before deploying the application.

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.camel.quarkus</groupId>
+      <artifactId>camel-quarkus-jsonpath</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.quarkus</groupId>
       <artifactId>camel-quarkus-bean</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/Constants.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/Constants.java
@@ -51,8 +51,10 @@ public final class Constants {
     public static final String REQUEST_CONTENT_PROPERTY = "requestContent";
     public static final String REPORT_PROPERTY = "report";
     public static final String PROVIDER_PRIVATE_DATA_PROPERTY = "providerPrivateData";
+    public static final String RESPONSE_STATUS_PROPERTY = "responseStatus";
 
     public static final String SNYK_DEP_GRAPH_API_PATH = "/test/dep-graph";
+    public static final String SNYK_TOKEN_API_PATH = "/user/me";
     public static final String TIDELIFT_API_BASE_PATH = "/packages";
     public static final String TIDELIFT_RELEASES_PATTERN = "/%s/%s/releases/%s";
     public static final String TRUSTED_CONTENT_PATH = "/api/policy/v1alpha1/trusted::gav";

--- a/src/main/resources/META-INF/openapi.yaml
+++ b/src/main/resources/META-INF/openapi.yaml
@@ -7,15 +7,17 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: 3.0.0
 servers:
-- url: http://crda-backend-crda.apps.sssc-cl01.appeng.rhecoeng.com/api/v3/
+- url: http://crda-backend-crda.apps.sssc-cl01.appeng.rhecoeng.com/api/v3
   description: Production server
-- url: http://localhost:8080/api/v3/
+- url: http://localhost:8080/api/v3
   description: Local development
 paths:
   /component-analysis/{pkgManager}:
     post:
       operationId: componentAnalysis
       summary: Performs a vulnerability for the provided components
+      security:
+        - SnykTokenAuth: []
       parameters:
       - name: pkgManager
         in: path
@@ -60,6 +62,8 @@ paths:
     post:
       operationId: dependencyAnalysis
       summary:  Takes a client-resolved dependency graph to perform a full stack analysis from all the available Vulnerability sources
+      security:
+        - SnykTokenAuth: []
       parameters:
       - name: pkgManager
         in: path
@@ -105,16 +109,19 @@ paths:
                     $ref: '#/components/schemas/AnalysisReport'
                   html_report:
                     type: object
+        '422':
+          description: Invalid request
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message  
   /token:
     get:
       operationId: validateToken
       summary: Validates a vulnerability provider token
-      parameters:
-      - name: crda-snyk-token
-        in: header
-        description: Snyk authentication token
-        schema:
-          type: string
+      security:
+        - SnykTokenAuth: []
       responses:
         '200':
           description: Successful token validation
@@ -139,6 +146,11 @@ paths:
                 description: Missing token
 
 components:
+  securitySchemes:
+    SnykTokenAuth:
+      type: apiKey
+      in: header
+      name: crda-snyk-token
   schemas:
     AnalysisReport:
       type: object

--- a/src/main/resources/META-INF/openapi.yaml
+++ b/src/main/resources/META-INF/openapi.yaml
@@ -105,6 +105,39 @@ paths:
                     $ref: '#/components/schemas/AnalysisReport'
                   html_report:
                     type: object
+  /token:
+    get:
+      operationId: validateToken
+      summary: Validates a vulnerability provider token
+      parameters:
+      - name: crda-snyk-token
+        in: header
+        description: Snyk authentication token
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Successful token validation
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Response message
+        '401':
+          description: Invalid token
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message
+        '400':
+          description: Invalid request
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Missing token
+
 components:
   schemas:
     AnalysisReport:

--- a/src/test/java/com/redhat/ecosystemappeng/crda/integration/TokenValidationIT.java
+++ b/src/test/java/com/redhat/ecosystemappeng/crda/integration/TokenValidationIT.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.crda.integration;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class TokenValidationIT extends TokenValidationTest {
+
+    // run the same tests
+
+}

--- a/src/test/java/com/redhat/ecosystemappeng/crda/integration/TokenValidationTest.java
+++ b/src/test/java/com/redhat/ecosystemappeng/crda/integration/TokenValidationTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.redhat.ecosystemappeng.crda.integration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import jakarta.ws.rs.core.MediaType;
+
+@QuarkusTest
+public class TokenValidationTest extends AbstractAnalysisTest {
+
+    private static final String ERROR_TOKEN = "fail";
+
+    @Test
+    public void testMissingToken() {
+        stubSnykToken(null);
+
+        String msg =
+                given().when()
+                        .get("/api/v3/token")
+                        .then()
+                        .assertThat()
+                        .statusCode(400)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .extract()
+                        .body()
+                        .asString();
+        assertEquals("Missing authentication header", msg);
+
+        verifyNoTokenInteractions();
+    }
+
+    @Test
+    public void testServerError() {
+        stubSnykToken(ERROR_TOKEN);
+
+        String msg =
+                given().when()
+                        .header(Constants.SNYK_TOKEN_HEADER, ERROR_TOKEN)
+                        .get("/api/v3/token")
+                        .then()
+                        .assertThat()
+                        .statusCode(500)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .extract()
+                        .body()
+                        .asString();
+        assertEquals("Unable to validate Snyk token", msg);
+
+        verifyTokenApiCall(ERROR_TOKEN);
+    }
+
+    @Test
+    public void testUnauthorizedError() {
+        String token = "other";
+        stubSnykToken("some token");
+
+        String msg =
+                given().when()
+                        .header(Constants.SNYK_TOKEN_HEADER, token)
+                        .get("/api/v3/token")
+                        .then()
+                        .assertThat()
+                        .statusCode(401)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .extract()
+                        .body()
+                        .asString();
+        assertEquals("Invalid auth token provided", msg);
+
+        verifyTokenApiCall(token);
+    }
+
+    @Test
+    public void testValidToken() {
+        String token = "some token";
+        stubSnykToken(token);
+
+        String msg =
+                given().when()
+                        .header(Constants.SNYK_TOKEN_HEADER, token)
+                        .get("/api/v3/token")
+                        .then()
+                        .assertThat()
+                        .statusCode(200)
+                        .contentType(MediaType.TEXT_PLAIN)
+                        .extract()
+                        .body()
+                        .asString();
+        assertEquals("Token validated successfully", msg);
+
+        verifyTokenApiCall(token);
+    }
+
+    private void stubSnykToken(String token) {
+        server.stubFor(
+                get(Constants.SNYK_TOKEN_API_PATH)
+                        .withHeader("Authorization", WireMock.equalTo("token " + token))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(200)
+                                        .withHeader(
+                                                Exchange.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                                        .withBodyFile("snyk_report.json")));
+        server.stubFor(
+                get(Constants.SNYK_TOKEN_API_PATH)
+                        .withHeader(
+                                "Authorization", WireMock.not(WireMock.equalTo("token " + token)))
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(401)
+                                        .withBody(
+                                                "{\"code\": 401, \"error\": \"Invalid auth token"
+                                                        + " provided\", \"message\": \"Invalid auth"
+                                                        + " token provided\"}")));
+
+        server.stubFor(
+                get(Constants.SNYK_TOKEN_API_PATH)
+                        .withHeader("Authorization", WireMock.equalTo("token " + ERROR_TOKEN))
+                        .willReturn(aResponse().withStatus(500)));
+    }
+
+    private void verifyNoTokenInteractions() {
+        server.verify(0, getRequestedFor(urlEqualTo(Constants.SNYK_TOKEN_API_PATH)));
+    }
+
+    private void verifyTokenApiCall(String token) {
+        server.verify(
+                1,
+                getRequestedFor(urlEqualTo(Constants.SNYK_TOKEN_API_PATH))
+                        .withHeader("Authorization", WireMock.equalTo("token " + token)));
+    }
+}


### PR DESCRIPTION
Add token validation endpoint to allow clients validate the token without having to send a vulnerability request.
This is useful when configuring the CLI or IDE.