### PR TITLE
ci: prevent the inform cli workflow from running and failing in forks

### DIFF
--- a/.github/workflows/inform-cli.yml
+++ b/.github/workflows/inform-cli.yml
@@ -12,6 +12,7 @@ jobs:
   inform_cli_spec_change:
     runs-on: ubuntu-latest
     name: Dispatch event for CLI
+    if: github.repository == 'RHEcosystemAppEng/crda-backend'
     steps:
       - name: Dispatch
         uses: actions/github-script@v6


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>
