### PR TITLE
feat: Refine error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ The possible responses are:
 - 200 - Token validated successfully
 - 400 - Missing authentication header
 - 401 - Invalid auth token provided
+- 403 - The token is not authorized
+- 429 - Rate limit exceeded
 - 500 - Server error
 
 ## Deploy on OpenShift

--- a/src/main/java/com/redhat/ecosystemappeng/crda/integration/snyk/SnykIntegration.java
+++ b/src/main/java/com/redhat/ecosystemappeng/crda/integration/snyk/SnykIntegration.java
@@ -146,8 +146,7 @@ public class SnykIntegration extends EndpointRouteBuilder {
     if (cause != null) {
       if (cause instanceof HttpOperationFailedException) {
         HttpOperationFailedException httpException = (HttpOperationFailedException) cause;
-        builder.message(httpException.getMessage()).status(httpException.getStatusCode());
-
+        builder.message(prettifyHttpError(httpException)).status(httpException.getStatusCode());
       } else {
         builder
             .message(cause.getMessage())
@@ -159,5 +158,19 @@ public class SnykIntegration extends EndpointRouteBuilder {
           .status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
     }
     exchange.getMessage().setBody(builder.build());
+  }
+
+  private String prettifyHttpError(HttpOperationFailedException httpException) {
+    String text = httpException.getStatusText();
+    switch (httpException.getStatusCode()) {
+      case 401:
+        return text + ": Verify the provided credentials are valid.";
+      case 403:
+        return text + ": The provided credentials don't have the required permissions.";
+      case 429:
+        return text + ": The rate limit has been exceeded.";
+      default:
+        return text;
+    }
   }
 }

--- a/src/main/resources/META-INF/openapi.yaml
+++ b/src/main/resources/META-INF/openapi.yaml
@@ -140,6 +140,20 @@ paths:
               schema:
                 type: string
                 description: Error message
+        '403':
+          description: Forbidden. The token does not have permissions
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message
+        '429':
+          description: Too many requests. Rate limit exceeded
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Error message
         '400':
           description: Invalid request
           content:

--- a/src/test/resources/__files/report_error.html
+++ b/src/test/resources/__files/report_error.html
@@ -184,7 +184,7 @@
   </div>
   <p class="pf-c-alert__title">
     <span class="pf-screen-reader">snyk:</span>
-    Snyk: HTTP operation failed invoking __WIREMOCK_URL__ with statusCode: 500
+    Snyk: Server Error
   </p>
 </div>
 <br />

--- a/src/test/resources/__files/report_unauthorized.html
+++ b/src/test/resources/__files/report_unauthorized.html
@@ -184,7 +184,7 @@
   </div>
   <p class="pf-c-alert__title">
     <span class="pf-screen-reader">snyk:</span>
-    Snyk: HTTP operation failed invoking __WIREMOCK_URL__ with statusCode: 401
+    Snyk: Unauthorized: Verify the provided credentials are valid.
   </p>
 </div>
 <br />


### PR DESCRIPTION
Provide a more detailed message in the providerStatuses response and in the HTML report.

Fix #68 

```json
"providerStatuses": [
    {
        "message": "Unauthorized: Verify the credentials provided are valid.",
        "ok": false,
        "provider": "snyk",
        "status": 401
    }
]
```

```json
"providerStatuses": [
    {
        "message": "Unauthorized: The provided credentials don't have the required permissions.",
        "ok": false,
        "provider": "snyk",
        "status": 403
    }
]
```

```json
"providerStatuses": [
    {
        "message": "Too many requests: The rate limit has been exceeded.",
        "ok": false,
        "provider": "snyk",
        "status": 429
    }
]
```