### PR TITLE
ci: update inform-cli workflow to inform the api libs instead of the cli

### DIFF
--- a/.github/workflows/inform-cli.yml
+++ b/.github/workflows/inform-cli.yml
@@ -19,8 +19,10 @@ jobs:
         with:
           github-token: ${{ secrets.CRDA_CLI_REPO_PAT }}
           script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: "RHEcosystemAppEng",
-              repo: "crda-cli",
-              event_type: "backend-openapi-spec-modified"
+            ['crda-java-api', 'crda-javascript-api'].forEach(repo => {
+              await github.rest.repos.createDispatchEvent({
+                owner: "RHEcosystemAppEng",
+                repo: repo,
+                event_type: "backend-openapi-spec-modified"
+              })
             })


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

The [crda-cli](https://github.com/RHEcosystemAppEng/crda-cli) project is being dropped.
The _inform-cli_ workflow should inform the api libs projects, [crda-javascript-api](https://github.com/RHEcosystemAppEng/crda-javascript-api) and [crda-java-api](https://github.com/RHEcosystemAppEng/crda-java-api), instead.
